### PR TITLE
Fix issue with reparenting

### DIFF
--- a/nsot/models.py
+++ b/nsot/models.py
@@ -810,17 +810,10 @@ class Network(AttributeModelMixin, Model):
             Network.parent_id == self.parent_id,
             Network.id != self.id,  # Don't include yourself...
             Network.prefix_length > self.prefix_length,
+            Network.ip_version == self.ip_version,
+            Network.network_address >= self.network_address,
+            Network.broadcast_address <= self.broadcast_address
         )
-
-        # When adding a new root we're going to reparenting a subset
-        # of roots so it's a bit more complicated so limit to all subnetworks
-        if self.parent_id is None:
-            query = query.filter(
-                Network.is_ip == False,
-                Network.ip_version == self.ip_version,
-                Network.network_address >= self.network_address,
-                Network.broadcast_address <= self.broadcast_address
-            )
 
         query.update({Network.parent_id: self.id})
 

--- a/tests/model_tests/test_regressions.py
+++ b/tests/model_tests/test_regressions.py
@@ -1,0 +1,17 @@
+from nsot import models
+
+from .fixtures import session, site, user, admin
+
+
+def test_reparent_bug_issues_27(session, admin, site):
+    """
+        Test for bug described at https://github.com/dropbox/nsot/issues/27
+    """
+
+    net_8  = models.Network.create(session, admin.id, site.id, u"10.0.0.0/8")
+    net_31 = models.Network.create(session, admin.id, site.id, u"10.17.244.128/31")
+    net_25 = models.Network.create(session, admin.id, site.id, u"10.16.1.0/25")
+
+    assert net_8.parent_id is None
+    assert net_31.parent_id == net_8.id
+    assert net_25.parent_id == net_8.id


### PR DESCRIPTION
Fixes: #27

Previously I attempted to be more intelligent about reparenting when not
a root reparent. This logic was buggy so use the more expensive lookup
always. This is a mild performance regression on inserts but is worth
it for correctness.