### PR TITLE
Enhance #83: Hook functionality

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -146,9 +146,30 @@ Events
 
 Events are in the form of ``[resource].[action]``, lowercased. For example::
 
-    device.create
-    device.update
-    device.delete
-    network.create
-    site.create
-    ...
+* device.create
+* device.update
+* device.delete
+* network.create
+* site.create
+
+POST Format
+~~~~~~~~~~~
+
+The format of the payload to ``POST`` to ``target``:
+
+.. code:: json
+
+    {
+        "hook": {
+            "target": "http://localhost:8991",
+            "id": 5,
+            "event": "device.update"
+        },
+        "data": {
+            "attributes": {},
+            "hostname": "updated.example.com",
+            "site_id": 1,
+            "id": 10
+        }
+    }
+

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -110,3 +110,45 @@ An example response for querying the ``sites`` endpoint might look like:
         }
     }
 
+Hooks
+-----
+
+As described in the intro, hooks are a way to subscribe to the events of
+resource types. This can let you write applications that rely on NSoT without
+needing to pull the entire list of resources all the time.
+
+* To create hooks: ``POST /api/hooks/``
+* To update hooks: ``PUT /api/hooks/[id]``
+* To delete hooks: ``PUT /api/hooks/[id]``
+
+Payload for creating and updating:
+
+.. code:: json
+
+   {
+       "event": "device.create",
+       "target": "http://url/to/post/to",
+       "global_hook": true
+   }
+
+
++-------------+-------------------------------------------------------------+
+| event       | Event to subscribe to                                       |
++-------------+-------------------------------------------------------------+
+| target      | Location to update everytime the chosen event happens       |
++-------------+-------------------------------------------------------------+
+| global_hook | Bool. Global hooks ensure every change is posted regardless |
+|             | of which user did it                                        |
++-------------+-------------------------------------------------------------+
+
+Events
+~~~~~~
+
+Events are in the form of ``[resource].[action]``, lowercased. For example::
+
+    device.create
+    device.update
+    device.delete
+    network.create
+    site.create
+    ...

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -60,3 +60,12 @@ All Create/Update/Delete events are logged as a Change. A Change includes
 information such as the change time, user, and the full resource after
 modification. Changes are immutable and can only be removed by deleting
 the entire Site.
+
+REST Hooks
+----------
+
+Any resource that logs **C**\R\ **UD** events as a Change has an event that can
+be subscribed to.
+
+Hooks are a way to tell NSoT to POST to a URL as events happen. More
+information on managing them is under the API docs.

--- a/nsot/api/urls.py
+++ b/nsot/api/urls.py
@@ -32,6 +32,9 @@ router.register(r'networks', views.NetworkViewSet)
 router.register(r'users', views.UserViewSet)
 router.register(r'values', views.ValueViewSet)
 
+# REST Hooks views
+router.register(r'hooks', views.HookViewSet)
+
 # Wire up our API using automatic URL routing.
 # Additionally, we include login URLs for the browsable API.
 urlpatterns = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ django-polymorphic==0.7
 django-rest-swagger==0.2.9
 djangorestframework==3.1.1
 djangorestframework-bulk==0.2.1
+django-rest-hooks-ng==1.1.1
 drf-nested-routers==0.9.0
 gevent==1.0.2
 gunicorn==19.3.0


### PR DESCRIPTION
### Commit log

```
POST to /api/hooks/ works to create new hooks
PUT to /api/hooks/[id]/ works to update existing hooks
DELETE to /api/hooks/[id]/ works to delete existing hooks

User will be inferred from the current authenticated one which
means either in X-NSoT-Email header or Auth_Token.

If trying to POST an existing token, an error similar to the normal
one is returned (HTTP 400 {status: error, error: { message: Hook must be unique, code: 400 } } )
```
### Notes

This is ready to merge, but is lacking unittests therefore don't merge until we have some for it. Still this is progress!
