### PR TITLE
Implemented API version 1.0 w/ feature toggle.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,20 @@
 language: python
+
 python:
-- '2.7'
+    - '2.7'
+
 install:
-- pip install -r requirements-dev.txt
-- pip install .
-script: py.test -vv tests/
+    - pip install -r requirements-dev.txt
+    - pip install .
+
+script:
+    - py.test -vv tests/
+    - NSOT_API_VERSION=1.0 py.test -vv tests/api_tests/
+
 after_success: curl -X POST http://readthedocs.org/build/nsot
+
 notifications:
   slack:
     secure: UdmH92LEpYke+NnslEx5lE4vjuqu719Wl5OPQPHPUACaKb1teA2yew5YjR/GxWh0Gy9nOcxpSL6xw1ODj3v6EzjvtVAcOzScFHbYUemdWlPLlYE5r9/rYIYVEChYIPQJ3uEhPJRys9ugXcZBdH2vgeXF4FW8Ftjxoqd+XCExB04=
+
 sudo: false

--- a/nsot/api/pagination.py
+++ b/nsot/api/pagination.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from collections import OrderedDict
+from django.conf import settings
 from django.template import Context, loader
 import logging
 from rest_framework import pagination
@@ -24,6 +25,13 @@ class CustomPagination(pagination.LimitOffsetPagination):
         self.request = request
         if self.count > self.limit and self.template is not None:
             self.display_page_controls = True
+
+        if request.version == settings.NSOT_API_VERSION:
+            if self.limit is None:
+                return None
+            return super(CustomPagination, self).paginate_queryset(
+                queryset, request, view
+            )
 
         # If we have a limit, slice it
         if self.limit:
@@ -60,6 +68,9 @@ class CustomPagination(pagination.LimitOffsetPagination):
         log.debug('request URI = %s' % self.request.build_absolute_uri())
         log.debug('request path = %s' % self.request.path)
         log.debug('request path_info = %s' % self.request.path_info)
+
+        if self.request.version == settings.NSOT_API_VERSION:
+            return super(CustomPagination, self).get_paginated_response(data)
 
         # If path is '/api/sites/1/attributes/', this is 'attributes'
         if result_key is None:

--- a/nsot/conf/settings.py
+++ b/nsot/conf/settings.py
@@ -141,6 +141,8 @@ TEMPLATES = [
 ##################
 # REST Framework #
 ##################
+# Release version of the API to publish.
+NSOT_API_VERSION = '1.0'
 
 # Settings for Django REST Framework (DRF)
 REST_FRAMEWORK = {
@@ -151,6 +153,9 @@ REST_FRAMEWORK = {
         # 'rest_framework.renderers.AdminRenderer',
     ],
     'DEFAULT_PAGINATION_CLASS': 'nsot.api.pagination.CustomPagination',
+    'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.AcceptHeaderVersioning',
+    'DEFAULT_VERSION': None,  # Change this when we change default e.g. '1.0'
+    # 'DEFAULT_VERSION': NSOT_API_VERSION,  # Change this when we change default e.g. '1.0'
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAdminUser',
     ),

--- a/tests/api_tests/conftest.py
+++ b/tests/api_tests/conftest.py
@@ -17,3 +17,8 @@ with betamax.Betamax.configure() as config:
 
     config.cassette_library_dir = 'tests/api_tests/cassettes'
     config.default_cassette_options['record_mode'] = 'all'
+
+
+def pytest_report_header(config):
+    api_version = os.getenv('NSOT_API_VERSION')
+    return 'Using NSoT API version: %s' % api_version

--- a/tests/api_tests/fixtures.py
+++ b/tests/api_tests/fixtures.py
@@ -1,6 +1,7 @@
 from django.core.urlresolvers import reverse
 import json
 import logging
+import os
 import pytest
 from pytest_django.fixtures import live_server, django_user_model
 import requests
@@ -9,6 +10,10 @@ from .util import Client, TestSite
 
 
 log = logging.getLogger(__name__)
+
+
+# API version to use for the API client
+API_VERSION = os.getenv('NSOT_API_VERSION')
 
 
 @pytest.fixture
@@ -24,10 +29,17 @@ def site(live_server):
     site_uri = reverse('site-list')  # /api/sites/
     resp = client.create(site_uri, name='Test Site')
 
-    site = TestSite(resp.json()['data']['site'])
+    site = TestSite(resp.json())
     return site
 
 
 @pytest.fixture
 def client(live_server):
-    return Client(live_server)
+    """Create and return an admin client."""
+    return Client(live_server, api_version=API_VERSION)
+
+
+@pytest.fixture
+def user_client(live_server):
+    """Create and return a non-admin client."""
+    return Client(live_server, user='user', api_version=API_VERSION)

--- a/tests/api_tests/test_permissions.py
+++ b/tests/api_tests/test_permissions.py
@@ -12,40 +12,37 @@ import json
 import logging
 from rest_framework import status
 
-from .fixtures import live_server, client, user, site
+from .fixtures import live_server, client, user, site, user_client
 from .util import (
     assert_created, assert_error, assert_success, assert_deleted, load_json,
-    Client, load
+    Client, load, get_result
 )
 
 
 log = logging.getLogger(__name__)
 
 
-def test_permissions(live_server, user, site):
-    admin_client = Client(live_server, 'admin')
-    user_client = Client(live_server, 'user')
-
+def test_permissions(client, user_client, user, site):
     # URIs
     attr_uri = site.list_uri('attribute')
     net_uri = site.list_uri('network')
     dev_uri = site.list_uri('device')
 
     # Create an Attribute
-    attr_resp = admin_client.create(
+    attr_resp = client.create(
         attr_uri, resource_name='Network', name='attr1'
     )
-    attr = attr_resp.json()['data']['attribute']
+    attr = get_result(attr_resp)
     attr_obj_uri = site.detail_uri('attribute', id=attr['id'])
 
     # Create a Network
-    net_resp = admin_client.create(net_uri, cidr='10.0.0.0/24')
-    net = net_resp.json()['data']['network']
+    net_resp = client.create(net_uri, cidr='10.0.0.0/24')
+    net = get_result(net_resp)
     net_obj_uri = site.detail_uri('network', id=net['id'])
 
     # Create a Device
-    dev_resp = admin_client.create(dev_uri, hostname='dev1')
-    dev= dev_resp.json()['data']['device']
+    dev_resp = client.create(dev_uri, hostname='dev1')
+    dev = get_result(dev_resp)
     dev_obj_uri = site.detail_uri('device', id=dev['id'])
 
     # User shouldn't be able to update site or create/update other resources

--- a/tests/api_tests/test_user.py
+++ b/tests/api_tests/test_user.py
@@ -16,7 +16,7 @@ from rest_framework import status
 from .fixtures import live_server, client, user, site
 from .util import (
     assert_created, assert_error, assert_success, assert_deleted, load_json,
-    Client, load
+    Client, load, get_result
 )
 
 
@@ -32,28 +32,29 @@ def test_user_with_secret_key(live_server):
 
     # Small requests to make user accounts in order.
     user1_resp = user1_client.get(user_uri)
-    user1 = user1_resp.json()['data']['user']
+    user1 = get_result(user1_resp)
     user1_uri = reverse('user-detail', args=(user1['id'],))
 
     user2_resp = user2_client.get(user_uri)
-    user2 = user2_resp.json()['data']['user']
+    user2 = get_result(user2_resp)
     user2_uri = reverse('user-detail', args=(user2['id'],))
 
     # User should be able to get user 0 (self)
     assert_success(
         user1_client.get(user_uri),
-        {'user': user1}
+        user1
     )
 
     # And see their own secret key as user 0
     response = user1_client.get(user_uri + '?with_secret_key')
     expected = copy.deepcopy(user1)
-    expected['secret_key'] = response.json()['data']['user']['secret_key']
-    assert_success(response, {'user': expected})
+    result = get_result(response)
+    expected['secret_key'] = result['secret_key']
+    assert_success(response, expected)
 
     # And their own secret key by their user id 
     response = user1_client.get(user1_uri + '?with_secret_key')
-    assert_success(response, {'user': expected})
+    assert_success(response, expected)
 
     # But not user 2's secret_key.
     response = user1_client.get(user2_uri + '?with_secret_key')
@@ -69,11 +70,11 @@ def test_user_rotate_secret_key(live_server):
 
     # Small requests to make user accounts in order.
     user1_resp = user1_client.get(user_uri)
-    user1 = user1_resp.json()['data']['user']
+    user1 = get_result(user1_resp)
     user1_key_uri = reverse('user-rotate-secret-key', args=(user1['id'],))
 
     user2_resp = user2_client.get(user_uri)
-    user2 = user2_resp.json()['data']['user']
+    user2 = get_result(user2_resp)
     user2_key_uri = reverse('user-rotate-secret-key', args=(user2['id'],))
 
     # User1 should be able to rotate their own secret_key

--- a/tests/api_tests/test_values.py
+++ b/tests/api_tests/test_values.py
@@ -15,7 +15,7 @@ from rest_framework import status
 from .fixtures import live_server, client, user, site
 from .util import (
     assert_created, assert_error, assert_success, assert_deleted, load_json,
-    Client, load, filter_values
+    Client, load, filter_values, get_result
 )
 
 
@@ -24,7 +24,6 @@ log = logging.getLogger(__name__)
 
 def test_filters(site, client):
     """Test field-based filters for Values."""
-
     # URIs
     attr_uri = site.list_uri('attribute')
     dev_uri = site.list_uri('device')
@@ -38,15 +37,12 @@ def test_filters(site, client):
 
     # Get all the Values for testing
     val_resp = client.get(val_uri)
-    values_out = val_resp.json()['data']
-    values = values_out['values']
+    values = get_result(val_resp)
 
     # Test lookup by name
-    expected = copy.deepcopy(values_out)
     kwargs = {'name': 'owner'}
     wanted = filter_values(values, **kwargs)
-    expected['values'] = wanted
-    expected.update({'limit': None, 'offset': 0, 'total': len(wanted)})
+    expected = wanted
     assert_success(
         client.retrieve(val_uri, **kwargs),
         expected
@@ -55,8 +51,7 @@ def test_filters(site, client):
     # Test lookup by name + value
     kwargs = {'name': 'owner', 'value': 'jathan'}
     wanted = filter_values(values, **kwargs)
-    expected['values'] = wanted
-    expected.update({'total': len(wanted)})
+    expected = wanted
     assert_success(
         client.retrieve(val_uri, **kwargs),
         expected
@@ -65,8 +60,7 @@ def test_filters(site, client):
     # Test lookup by resource_name + resource_id
     kwargs = {'resource_name': 'Device', 'resource_id': 4}
     wanted = filter_values(values, **kwargs)
-    expected['values'] = wanted
-    expected.update({'total': len(wanted)})
+    expected = wanted
     assert_success(
         client.retrieve(val_uri, **kwargs),
         expected

--- a/tests/api_tests/test_xforwardfor.py
+++ b/tests/api_tests/test_xforwardfor.py
@@ -21,12 +21,16 @@ from .util import (
 log = logging.getLogger(__name__)
 
 def test_request_xforwardfor(live_server):
+    """Test processing of X-Forwarded-For header."""
     url = '{}/api/sites/'.format(live_server.url)
-    headers = {'X-NSoT-Email': 'gary@localhost',
-    'X-Forward-For':'10.1.1.1'
+    headers = {
+        'X-NSoT-Email': 'gary@localhost',
+        'X-Forward-For': '10.1.1.1'
     }
+
+    expected = []
 
     assert_success(
         requests.get(url, headers=headers),
-        {'sites': [], 'limit': None, 'offset': 0, 'total': 0}
+        expected
     )


### PR DESCRIPTION
- All views are now "version-aware".
- `Accept` header appended with `version=1.0` will enable new API style.
- Unit tests for API tests will be run once without API version set, and once with it set to `1.0`, you can see that reflected in the update to `.travis.yml`