### PR TITLE
Creates Dockerfile template w/ README

### DIFF
--- a/bump.sh
+++ b/bump.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/bash
+
+USAGE=`cat <<EOF
+Usage: bump [OPTIONS]...
+
+    Bump version of NSoT, updating the python package and Dockerfile
+
+Options:
+    -v, --version VERSION       Version to bump to
+    -b, --build                 Build and push dropbox/nsot docker image
+                                [default: false]
+EOF
+`
+
+function proceed() {
+    echo "Replace ${CURVER} with ${VERSION}? [Y\\n]"
+    read confirm
+    case ${confirm} in
+        y|Y|'' ) replace;;
+        n|N ) echo "Canceled" >&2 && exit 1;;
+        * ) proceed;;
+    esac
+}
+
+function replace() {
+    sed -i "s/'${CURVER}'/'${VERSION}'/" nsot/version.py && \
+        echo "Updated nsot/version.py"
+
+    sed "s/{{ NSOT_VERSION }}/${VERSION}/" docker/Dockerfile.sub > \
+        docker/Dockerfile && echo "Updated docker/Dockerfile"
+}
+
+function docker_build() {
+    # docker build -t dropbox/nsot -t dropbox/nsot:${VERSION} docker/ && \
+    #     docker push dropbox/nsot && \
+    #     docker push dropbox/nsot:${VERSION}
+    docker build -t blah docker/
+}
+
+function usage() {
+    echo "$USAGE" >&2
+    exit
+}
+
+# Entrypoint actually starts here
+
+while [[ $# > 0 ]]; do
+
+    key="$1"
+
+    case $key in
+        -h|--help)
+            usage
+            ;;
+        -v|--version)
+            VERSION="$2" && shift;;
+        -b|--build)
+            BUILD=1
+            ;;
+        *) ;;
+    esac
+    shift
+done
+
+if [ -z $VERSION ]; then echo "You must provide -v|--version!" >&2; usage; fi
+
+CURVER=`sed "s/^.*'\(\S*\)'/\1/" nsot/version.py`
+proceed
+
+if [ -z $BUILD ]; then
+    exit
+else
+    docker_build
+fi

--- a/bump.sh
+++ b/bump.sh
@@ -7,7 +7,6 @@ Usage: bump [OPTIONS]...
 
 Options:
     -v, --version VERSION       Version to bump to
-    -b, --build                 Build and push dropbox/nsot docker image
                                 [default: false]
 EOF
 `
@@ -30,13 +29,6 @@ function replace() {
         docker/Dockerfile && echo "Updated docker/Dockerfile"
 }
 
-function docker_build() {
-    # docker build -t dropbox/nsot -t dropbox/nsot:${VERSION} docker/ && \
-    #     docker push dropbox/nsot && \
-    #     docker push dropbox/nsot:${VERSION}
-    docker build -t blah docker/
-}
-
 function usage() {
     echo "$USAGE" >&2
     exit
@@ -54,9 +46,6 @@ while [[ $# > 0 ]]; do
             ;;
         -v|--version)
             VERSION="$2" && shift;;
-        -b|--build)
-            BUILD=1
-            ;;
         *) ;;
     esac
     shift
@@ -66,9 +55,3 @@ if [ -z $VERSION ]; then echo "You must provide -v|--version!" >&2; usage; fi
 
 CURVER=`sed "s/^.*'\(\S*\)'/\1/" nsot/version.py`
 proceed
-
-if [ -z $BUILD ]; then
-    exit
-else
-    docker_build
-fi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,44 @@
+FROM ubuntu:14.04
+MAINTAINER Codey oxley <codey.a.oxley+os@gmail.com>
+EXPOSE 8990
+
+# These are the supported environment variables.
+# Use them to control the 'default' Django database configuration:
+#     DB_ENGINE
+#     DB_NAME
+#     DB_USER
+#     DB_PASSWORD
+#     DB_HOST
+#     DB_PORT
+#
+#     NSOT_EMAIL
+#     NSOT_SECRET
+
+# Install necessary packages
+#
+# The development packages are for building certain dependencies that pip pulls
+# in
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get --quiet=2 update
+RUN apt-get --quiet=2 install -y \
+        python \
+        python-dev \
+        python-pip \
+        libffi6 \
+        libffi-dev \
+        libssl-dev \
+        libmysqlclient-dev \
+        curl
+
+RUN apt-get --quiet=2 install -y python-psycopg2
+RUN apt-get --quiet=2 install -y sqlite3
+RUN pip install MySQL-Python
+RUN pip install psycopg2
+
+# Try to run this as late as possible for layer caching - this version will be
+# updated every update so let the build not take longer than necessary
+RUN pip install nsot==0.15.4
+COPY conf /etc/nsot
+
+ENTRYPOINT ["nsot-server", "--config=/etc/nsot/nsot.conf.py"]
+CMD ["start", "--noinput", "--no-upgrade"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,11 +37,12 @@ RUN pip install psycopg2
 
 # Try to run this as late as possible for layer caching - this version will be
 # updated every update so let the build not take longer than necessary
-RUN pip install nsot==0.15.1
+RUN pip install nsot==0.15.4
 COPY conf /etc/nsot
 
 ENTRYPOINT ["nsot-server", "--config=/etc/nsot/nsot.conf.py"]
+
+# If using --no-upgrade then the database won't be built for first run. Use
+# should specify --no-upgrade manually if they don't want it
 CMD ["start", "--noinput"]
 # CMD ["start", "--noinput", "--no-upgrade"]
-# If using --no-upgrade then the database won't be built for first run. User
-# should specify --no-upgrade manually if they don't want it

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,8 +37,11 @@ RUN pip install psycopg2
 
 # Try to run this as late as possible for layer caching - this version will be
 # updated every update so let the build not take longer than necessary
-RUN pip install nsot==0.15.4
+RUN pip install nsot==0.15.1
 COPY conf /etc/nsot
 
 ENTRYPOINT ["nsot-server", "--config=/etc/nsot/nsot.conf.py"]
-CMD ["start", "--noinput", "--no-upgrade"]
+CMD ["start", "--noinput"]
+# CMD ["start", "--noinput", "--no-upgrade"]
+# If using --no-upgrade then the database won't be built for first run. User
+# should specify --no-upgrade manually if they don't want it

--- a/docker/Dockerfile.sub
+++ b/docker/Dockerfile.sub
@@ -41,4 +41,8 @@ RUN pip install nsot=={{ NSOT_VERSION }}
 COPY conf /etc/nsot
 
 ENTRYPOINT ["nsot-server", "--config=/etc/nsot/nsot.conf.py"]
-CMD ["start", "--noinput", "--no-upgrade"]
+
+# If using --no-upgrade then the database won't be built for first run. Use
+# should specify --no-upgrade manually if they don't want it
+CMD ["start", "--noinput"]
+# CMD ["start", "--noinput", "--no-upgrade"]

--- a/docker/Dockerfile.sub
+++ b/docker/Dockerfile.sub
@@ -1,0 +1,44 @@
+FROM ubuntu:14.04
+MAINTAINER Codey oxley <codey.a.oxley+os@gmail.com>
+EXPOSE 8990
+
+# These are the supported environment variables.
+# Use them to control the 'default' Django database configuration:
+#     DB_ENGINE
+#     DB_NAME
+#     DB_USER
+#     DB_PASSWORD
+#     DB_HOST
+#     DB_PORT
+#
+#     NSOT_EMAIL
+#     NSOT_SECRET
+
+# Install necessary packages
+#
+# The development packages are for building certain dependencies that pip pulls
+# in
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get --quiet=2 update
+RUN apt-get --quiet=2 install -y \
+        python \
+        python-dev \
+        python-pip \
+        libffi6 \
+        libffi-dev \
+        libssl-dev \
+        libmysqlclient-dev \
+        curl
+
+RUN apt-get --quiet=2 install -y python-psycopg2
+RUN apt-get --quiet=2 install -y sqlite3
+RUN pip install MySQL-Python
+RUN pip install psycopg2
+
+# Try to run this as late as possible for layer caching - this version will be
+# updated every update so let the build not take longer than necessary
+RUN pip install nsot=={{ NSOT_VERSION }}
+COPY conf /etc/nsot
+
+ENTRYPOINT ["nsot-server", "--config=/etc/nsot/nsot.conf.py"]
+CMD ["start", "--noinput", "--no-upgrade"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,86 @@
+# NSoT Docker Image
+
+This Docker image runs NSoT. Perfect for quick developing and even deploying in
+production.
+
+## Using this image
+
+Image tags should correspond with NSoT release version numbers. Basic usage is
+like:
+
+```bash
+
+$ SECRET='YkV0Q0lYT3RpN0ppMGZ2Q0tMVE8wbW55WjQ0QkFpdlBvUWpLbFpBTlVZSW1DVnZmMWFNTWpteDFGVDFKUXg2'
+$ docker run -p -d --name=nsot -e NSOT_SECRET=$SECRET dropbox/nsot:0.15.4
+```
+
+`nsot-server --config=/etc/nsot/nsot.conf.py` is the image entrypoint, so the
+command passed to docker run becomes CLI parameters. This is equivalent to what
+the default is:
+
+```
+$ docker run -p -d --name=nsot dropbox/nsot start --noinput --no-upgrade
+```
+
+If you wanted to do interactive debugging, use the docker run flags `-ti` and
+pass the relevant options:
+
+```bash
+$ docker run -p -ti --rm dropbox/nsot dbshell
+    SQLite version 3.8.2 2013-12-06 14:53:30
+    Enter ".help" for instructions
+    Enter SQL statements terminated with a ";"
+    sqlite> exit
+
+OR
+
+$ docker run -p -ti --rm dropbox/nsot shell_plus
+    # Shell Plus Model Imports
+    from django.contrib.admin.models import LogEntry
+    from django.contrib.auth.models import Group, Permission
+    from django.contrib.contenttypes.models import ContentType
+    from django.contrib.sessions.models import Session
+    from nsot.models import Assignment, Attribute, Change, Device, Interface,
+    Network, Site, User, Value
+    # Shell Plus Django Imports
+    from django.utils import timezone
+    from django.conf import settings
+    from django.core.cache import cache
+    from django.db.models import Avg, Count, F, Max, Min, Sum, Q, Prefetch
+    from django.core.urlresolvers import reverse
+    from django.db import transaction
+    Python 2.7.6 (default, Jun 22 2015, 17:58:13)
+    Type "copyright", "credits" or "license" for more information.
+
+    IPython 3.1.0 -- An enhanced Interactive Python.
+    ?         -> Introduction and overview of IPython's features.
+    %quickref -> Quick reference.
+    help      -> Python's own help system.
+    object?   -> Details about 'object', use 'object??' for extra details.
+
+    In [1]:
+```
+
+If you want to add an entire custom config, volume mount it to
+`/etc/nsot/nsot.conf.py`
+
+## Ports
+
+Only TCP 8990 is exposed
+
+## Environment Variales
+
+Pass these with `-e` to control the configuration. `NSOT_SECRET` should be the
+bare minimum set, setting an external DB if in production or wanting
+persistence should be second.
+
+| Variable            | Default Value    |
+|:--------------------|:-----------------|
+| `DB_ENGINE`         | `django.db.backends.sqlite3` |
+| `DB_NAME`           | `nsot.sqlite3`               |
+| `DB_USER`           | `nsot`                       |
+| `DB_PASSWORD`       | ''                           |
+| `DB_HOST`           | ''                           |
+| `DB_PORT`           | ''                           |
+| `NSOT_EMAIL`        | `X-NSoT-Email`               |
+| `NSOT_SECRET`       | `UGxlYXNlIGNoYW5nZSB0aGlzIQ==` ('Please change this!' base64) |

--- a/docker/README.md
+++ b/docker/README.md
@@ -19,8 +19,11 @@ command passed to docker run becomes CLI parameters. This is equivalent to what
 the default is:
 
 ```
-$ docker run -p -d --name=nsot dropbox/nsot start --noinput --no-upgrade
+$ docker run -p -d --name=nsot dropbox/nsot start --noinput
 ```
+
+If you have an established database and you don't wish to attempt to upgrade it
+then you'll need to specify `--no-upgrade`
 
 If you wanted to do interactive debugging, use the docker run flags `-ti` and
 pass the relevant options:

--- a/docker/README.md
+++ b/docker/README.md
@@ -11,7 +11,7 @@ like:
 ```bash
 
 $ SECRET='YkV0Q0lYT3RpN0ppMGZ2Q0tMVE8wbW55WjQ0QkFpdlBvUWpLbFpBTlVZSW1DVnZmMWFNTWpteDFGVDFKUXg2'
-$ docker run -p -d --name=nsot -e NSOT_SECRET=$SECRET dropbox/nsot:0.15.4
+$ docker run -p 8990:8990 -d --name=nsot -e NSOT_SECRET=$SECRET dropbox/nsot:0.15.4
 ```
 
 `nsot-server --config=/etc/nsot/nsot.conf.py` is the image entrypoint, so the
@@ -19,7 +19,7 @@ command passed to docker run becomes CLI parameters. This is equivalent to what
 the default is:
 
 ```
-$ docker run -p -d --name=nsot dropbox/nsot start --noinput
+$ docker run -p 8990:8990 -d --name=nsot dropbox/nsot start --noinput
 ```
 
 If you have an established database and you don't wish to attempt to upgrade it
@@ -29,7 +29,7 @@ If you wanted to do interactive debugging, use the docker run flags `-ti` and
 pass the relevant options:
 
 ```bash
-$ docker run -p -ti --rm dropbox/nsot dbshell
+$ docker run -p 8990:8990 -ti --rm dropbox/nsot dbshell
     SQLite version 3.8.2 2013-12-06 14:53:30
     Enter ".help" for instructions
     Enter SQL statements terminated with a ";"
@@ -37,7 +37,7 @@ $ docker run -p -ti --rm dropbox/nsot dbshell
 
 OR
 
-$ docker run -p -ti --rm dropbox/nsot shell_plus
+$ docker run -p 8990:8990 -ti --rm dropbox/nsot shell_plus
     # Shell Plus Model Imports
     from django.contrib.admin.models import LogEntry
     from django.contrib.auth.models import Group, Permission
@@ -87,3 +87,10 @@ persistence should be second.
 | `DB_PORT`           | ''                           |
 | `NSOT_EMAIL`        | `X-NSoT-Email`               |
 | `NSOT_SECRET`       | `UGxlYXNlIGNoYW5nZSB0aGlzIQ==` ('Please change this!' base64) |
+
+
+## Contributing
+
+This image is maintained upstream under `docker/Dockerfile.sub` template.
+Changes to `docker/Dockerfile` will be overwritten during the next version
+bump.

--- a/docker/conf/nsot.conf.py
+++ b/docker/conf/nsot.conf.py
@@ -13,7 +13,7 @@ from nsot.conf.settings import *  # noqa
 import os
 
 # Path where the config is found.
-CONF_ROOT = os.path.dirname(__file__)
+CONF_ROOT = '/etc/nsot'
 
 # A boolean that turns on/off debug mode. Never deploy a site into production
 # with DEBUG turned on.
@@ -41,7 +41,7 @@ DATABASES = {
 
 # The address on which the application will listen.
 # Default: localhost
-NSOT_HOST = 'localhost'
+NSOT_HOST = '0.0.0.0'
 
 # The port on which the application will be accessed.
 # Default: 8990

--- a/docker/conf/nsot.conf.py
+++ b/docker/conf/nsot.conf.py
@@ -1,0 +1,77 @@
+"""
+This configuration file is just Python code. You may override any global
+defaults by specifying them here.
+
+For more information on this file, see
+https://docs.djangoproject.com/en/1.8/topics/settings/
+
+For the full list of settings and their values, see
+https://docs.djangoproject.com/en/1.8/ref/settings/
+"""
+from nsot.conf.settings import *  # noqa
+
+import os
+
+# Path where the config is found.
+CONF_ROOT = os.path.dirname(__file__)
+
+# A boolean that turns on/off debug mode. Never deploy a site into production
+# with DEBUG turned on.
+# Default: False
+DEBUG = False
+
+############
+# Database #
+############
+# https://docs.djangoproject.com/en/dev/ref/settings/#databases
+DATABASES = {
+    'default': {
+        'ENGINE': os.environ.get('DB_ENGINE', 'django.db.backends.sqlite3'),
+        'NAME': os.environ.get('DB_NAME', 'nsot.sqlite3'),
+        'USER': os.environ.get('DB_USER', 'nsot'),
+        'PASSWORD': os.environ.get('DB_PASSWORD', ''),
+        'HOST': os.environ.get('DB_HOST', ''),
+        'PORT': os.environ.get('DB_PORT', '')
+    }
+}
+
+###############
+# Application #
+###############
+
+# The address on which the application will listen.
+# Default: localhost
+NSOT_HOST = 'localhost'
+
+# The port on which the application will be accessed.
+# Default: 8990
+NSOT_PORT = 8990
+
+# If True, serve static files directly from the app.
+# Default: True
+SERVE_STATIC_FILES = True
+
+############
+# Security #
+############
+
+# A URL-safe base64-encoded 32-byte key. This must be kept secret. Anyone with
+# this key is able to create and read messages. This key is used for
+# encryption/decryption of sessions and auth tokens.
+SECRET_KEY = os.environ.get('NSOT_SECRET', 'UGxlYXNlIGNoYW5nZSB0aGlzIQ==')
+
+# Header to check for Authenticated Email. This is intended for use behind an
+# authenticating reverse proxy.
+USER_AUTH_HEADER = os.environ.get('NSOT_EMAIL', 'X-NSoT-Email')
+
+# The age, in seconds, until an AuthToken granted by the API will expire.
+# Default: 600
+AUTH_TOKEN_EXPIRY = 600  # 10 minutes
+
+# A list of strings representing the host/domain names that this Django site
+# can serve. This is a security measure to prevent an attacker from poisoning
+# caches and triggering password reset emails with links to malicious hosts by
+# submitting requests with a fake HTTP Host header, which is possible even
+# under many seemingly-safe web server configurations.
+# https://docs.djangoproject.com/en/1.8/ref/settings/#allowed-hosts
+ALLOWED_HOSTS = ['*']


### PR DESCRIPTION
This is in reference to #164 

This creates the `docker` directory which holds files necessary to understand
and build the docker image.

In my mind the Docker tag (version) should be in sync with upstream project
version. Because of this I've also added `bump.sh` which will update both
`nsot/version.py` and Dockerfile when versions are bumped. If `-b` is passed,
then it will also build and push the Docker image to dropbox/nsot.

If this isn't desired for the version bumping workflow, something should be implemented whether it's https://github.com/peritus/bumpversion or something else just to make it a one-stop-shop.