### PR TITLE
More documentation!

### DIFF
--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -1,5 +1,6 @@
+########
 REST API
-========
+########
 
 NSoT is designed as an API-first application so that all possible actions are
 published as API endpoints.
@@ -7,22 +8,34 @@ published as API endpoints.
 .. _api-ref:
 
 API Reference
--------------
+=============
 
 Interactive API reference documentation can be found by browsing to ``/docs/``
 on a running NSoT server instance.
 
+.. _browsable-api:
+
+Browsable API
+=============
+
+Because NSoT is an API-first application, the REST API is central to the
+experience. The REST API can support JSON or can also be used directly from
+your web browser. This version is called the "browsable API" and while it
+doesn't facilitate automation, it can be very useful.
+
+Visit ``/api/`` in your browser on your installed instance. How cool is that?!
+
 .. _api-auth:
 
 Authentication
---------------
+==============
 
 Two methods of authentication are currently supported.
 
 .. _api-auth_header:
 
 User Authentication Header
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------
 
 This is referred to internally as **auth_header** authentication.
 
@@ -40,7 +53,7 @@ so:
 .. _api-auth_token:
 
 AuthToken
-~~~~~~~~~
+---------
 
 This is referred to internally as **auth_token** authentication.
 
@@ -62,7 +75,7 @@ that is formatted like so:
     Authorization: AuthToken {email}:{secret_key}
 
 Requests
---------
+========
 
 In addition to the authentication header above all ``POST``, ``PUT``, and
 ``PATCH``, requests will be sent as ``JSON`` rather than form data and should
@@ -75,8 +88,11 @@ fields may revert to their default values, depending on the object type.
 ``PATCH`` allows for partial update of objects for most fields, depending on
 the object type.
 
+``OPTIONS`` will provide the schema for any endpoint.
+
 Responses
----------
+=========
+
 All responses will be in format along with the header ``Content-Type:
 application/json`` set.
 
@@ -105,7 +121,7 @@ will contain an error ``code`` and ``message``.
     }
 
 Pagination
-----------
+==========
 
 All responses that return a list of resources will support pagination. If the
 ``results`` object on the response has a ``count`` attribute then the endpoint
@@ -141,3 +157,86 @@ An example response for querying the ``sites`` endpoint might look like:
         ]
     }
 
+Schemas
+=======
+
+By performing an ``OPTIONS`` query on any endpoint, you can obtain the schema
+of the resource for that endpoint. This includes supported content-types, HTTP
+actions, the fields allowed for each action, and their attributes.
+
+An example response for the schema for the ``devices`` endpoint might look like:
+
+**Request**:
+
+.. code-block:: http
+
+    OPTIONS http://localhost:8990/api/devices/
+
+**Response**:
+
+.. code-block:: javascript
+
+    HTTP 200 OK
+    Allow: GET, POST, PUT, PATCH, HEAD, OPTIONS
+    Content-Type: application/json
+    Vary: Accept
+
+    {
+        "name": "Device List",
+        "description": "API endpoint that allows Devices to be viewed or edited.",
+        "renders": [
+            "application/json",
+            "text/html"
+        ],
+        "parses": [
+            "application/json",
+            "application/x-www-form-urlencoded",
+            "multipart/form-data"
+        ],
+        "actions": {
+            "PUT": {
+                "id": {
+                    "type": "integer",
+                    "required": false,
+                    "read_only": true,
+                    "label": "ID"
+                },
+                "hostname": {
+                    "type": "string",
+                    "required": true,
+                    "read_only": false,
+                    "label": "Hostname",
+                    "max_length": 255
+                },
+                "attributes": {
+                    "type": "field",
+                    "required": true,
+                    "read_only": false,
+                    "label": "Attributes",
+                    "help_text": "Dictionary of attributes to set."
+                }
+            },
+            "POST": {
+                "hostname": {
+                    "type": "string",
+                    "required": true,
+                    "read_only": false,
+                    "label": "Hostname",
+                    "max_length": 255
+                },
+                "attributes": {
+                    "type": "field",
+                    "required": false,
+                    "read_only": false,
+                    "label": "Attributes",
+                    "help_text": "Dictionary of attributes to set."
+                },
+                "site_id": {
+                    "type": "integer",
+                    "required": true,
+                    "read_only": false,
+                    "label": "Site id"
+                }
+            }
+        }
+    }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,7 +36,10 @@ application = get_wsgi_application()
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    "sphinx.ext.autodoc"
+    'sphinx.ext.autodoc',
+    'sphinx.ext.todo',
+    'sphinx.ext.coverage',
+    'sphinx.ext.viewcode',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -53,7 +56,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Network Source of Truth'
-copyright = u'2014-2015, Dropbox, Inc.'
+copyright = u'2014-2016, Dropbox, Inc.'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,3 +37,9 @@ interfaces.
 .. |PyPI Status| image:: https://img.shields.io/pypi/v/nsot.svg?style=flat
    :target: https://pypi.python.org/pypi/nsot
    :width: 86px
+
+Logo_ by Vecteezy_ is licensed under `CC BY-SA 3.0`_
+
+.. _Logo: https://www.iconfinder.com/icons/532251
+.. _Vecteezy: https://www.iconfinder.com/Vecteezy
+.. _CC BY-SA 3.0: http://creativecommons.org/licenses/by-sa/3.0/

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -45,6 +45,20 @@ These guides go into detail on how to get running NSoT on virtual machines.
 
 .. _demo:
 
+Official Client
+===============
+
+We maintain the official NSoT client under a separate project called `pyNSoT
+<https://pynsot.readthedocs.org>`_. PyNSoT provides a Python API client and an
+excellent CLI utility.
+
+If you wish to utilize NSoT from the command-line, or follow along in the
+:doc:`tutorial`, you're going to need this!
+
+Installing the client is as easy as running ``pip install pynsot``. Setup is a
+breeze, too. If you run into any issues, please refer to the `official pyNSoT
+documentation <https://pynsot.readthedocs.org>`_.
+
 Demo
 ====
 

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -1,5 +1,6 @@
+##########
 Data Model
-==========
+##########
 
 The Network Source of Truth is composed of various object types that it is
 important to be familiar with. This document describes each object type.
@@ -9,70 +10,313 @@ important to be familiar with. This document describes each object type.
     :depth: 2
 
 Sites
------
+=====
 
 Sites function as unique namespaces that can contain all other objects. Sites
 allow an organization to have multiple instances of potentially conflicting
 objects. For example, this could be beneficial for isolating corporate vs.
 production environments, or pulling in the IP space of an acquisition.
 
+Every object must be related to a site and therefore the ``site_id`` field is
+used frequently to scope object lookups.
+
+A Site cannot be deleted unless it contains no other objects.
+
+A typical Site object might look like this:
+
+.. code-block:: javascript
+
+    {
+        "id": 1,
+        "name": "Demo Site",
+        "description": "This is a demonstration site for NSoT."
+    }
+
 Attributes
-----------
+==========
 
 Attributes are arbitrary key/value pairs that can be assigned to various
-resources. If an attribute is required then additions/updates for that resource
-will require that attribute be present.
+resources. Attributes have various flags and constraints to control how they
+may be used.
 
-Changes to attribute constraints are not retroactive. Existing resources will
-not be forcefully validated until updated.
+Attributes are bound to a *resource name* (e.g. Device). You may have multiple
+Attributes with the same name bound to different resource types.
+
+When assigned to objects, think of an Attribute as an instance of of an
+Attribute object with a Value object assigned to it. Objects may be looked up
+by their attribute/value pairs
+
+A typical Attribute object might look like this:
+
+.. code-block:: javascript
+
+    {
+        "multi": false,
+        "resource_name": "Device",
+        "description": "The device manufacturer.",
+        "display": true,
+        "required": true,
+        "site_id": 1,
+        "id": 2,
+        "constraints": {
+            "pattern": "",
+            "valid_values": [
+                "arista",
+                "cisco",
+                "juniper"
+            ],
+            "allow_empty": false
+        },
+        "name": "vendor"
+    }
+
+.. important::
+    Changes to attribute flags and constraints are not retroactive. Existing
+    resources will not be forcefully validated until updated.
 
 Values
-~~~~~~
+------
 
 Values contain atttribute values. These are never directly manipulated, but
 they are accessible from the API for utilty.
 
+All attribute values must be strings. If an attribute is a list type
+(``multi=True``), then the values for that attribute will be a list of strings.
+
+A typical Value object might look like:
+
+.. code-block:: javascript
+
+    {
+        "id": 8,
+        "name": "owner",
+        "value": "jathan",
+        "attribute": 5,
+        "resource_name": "Device",
+        "resource_id": 2
+    }
+
+Flags
+-----
+
+required
+    If an attribute is required then additions/updates for that resource will
+    require that attribute be present.
+
+display
+    Whether to display the attribute in the web UI. Required attributes are
+    always displayed.
+
+multi
+    Whether the attribute values should be treated as a list type
+
+Constraints
+-----------
+
+pattern
+    A regex pattern. If set, values for this attribute must match the pattern.
+
+allow_empty
+    Whether the attribute should require a value. This causes the attribute to
+    behave like a tag.
+
+valid_values
+    Valid values for this attribute. This causes the attribute to behave like
+    an enum.
+
 Resources
----------
+=========
 
-A Resource object is any object that can have attributes. There are three
-primary resource types:
+A Resource object is any object that can have attributes. The primary resource
+types are:
 
-+ Devices
-+ Networks
-+ Interfaces
+.. contents::
+    :local:
+    :depth: 1
 
 Devices
-~~~~~~~
+-------
 
-A device represents various hardware components on your network such as
+A Device represents various hardware components on your network such as
 routers, switches, console servers, pdus, servers, etc.
 
-Devices also support arbitrary attributes similar to Networks.
+Devices in their most basic form are represented by a hostname.
+
+Devices can contain zero or more Interfaces.
+
+A typical Device object might look like:
+
+.. code-block:: javascript
+
+    {
+        "attributes": {
+            "owner": "jathan",
+            "vendor": "juniper",
+            "hw_type": "router",
+            "metro": "lax"
+        },
+        "hostname": "lax-r1",
+        "site_id": 1,
+        "id": 1
+    }
 
 Networks
-~~~~~~~~
+--------
 
-A network resource can represent an IP Network and an IP Address. Working with
+Networks in NSoT are designed to provide IP Address Management (IPAM)
+features. A Network represents an IPv4 or IPv6 Network or IP address. Working with
 networks is usually done with CIDR notation.
 
-Networks can have any number of arbitrary attributes as defined below.
+Networks may be assigned to Interfaces by way of an *Assignment* relationship.
 
-Interfaces
+A typical Network object might look like:
+
+.. code-block:: javascript
+
+    {
+        "parent_id": null,
+        "state": "allocated",
+        "prefix_length": 8,
+        "is_ip": false,
+        "ip_version": "4",
+        "network_address": "10.0.0.0",
+        "attributes": {
+            "type": "internal"
+        },
+        "site_id": 1,
+        "id": 1
+    }
+
+Tree Traversal
+~~~~~~~~~~~~~~
+
+Networks are represented as tree objects. Anytime a network is added or
+deleted, the tree is automatically updated to reparent networks appropriately.
+
+Networks support all of the common tree traversal methods that you may expect
+from this type of object:
+
+parent
+    The parent of this network
+
+ancestors
+    All parents of the parent of this network
+
+siblings
+    Networks with the same parent as this network
+
+children
+    The child networks of this network
+
+descendents
+    All children of the children of this network
+
+closest_parent
+    If this network doesn't exist, who might its parent be if it did?
+
+subnets
+    Subnetworks of this network
+
+supernets
+    Supernets of this network
+
+State
+~~~~~
+
+Network state represents whether the Network is in use or not. The states are:
+
+allocated
+    The default state for any newly-created Network. It is implied that this
+    address is in use some how, but it is not a busy state.
+
+assigned
+    Used to represent a Network assigned to an Interface. This is a busy state.
+
+reserved
+    Used to represent that the Network is reserved for future use. This is a
+    busy state.
+
+orphaned
+    Used to represent a Network that was previously assigned or reserved but
+    has since drifted.
+
+Allocation
 ~~~~~~~~~~
 
-An interface represents a physical or logical network interface such as an
+Networks can be used to allocate child networks or addresses.
+
+next_network
+    Given a prefix_length, return the next available child Network of this
+    length.
+
+next_address
+    Given a number of addresses, return that many next available IP addresses.
+
+Interfaces
+----------
+
+An Interface represents a physical or logical network interface such as an
 ethernet port. Interfaces must always be associated with a device. Zero or
 more addresses may be assigned to an Interface, although the same address may
 not be assigned to more than one interface on the same device.
 
-Interfaces also support arbitrary attributes similar to Networks and Devices.
+A typical Interface object might look like:
 
-* Addresses TBD
-* Assignments TBD
+.. code-block:: javascript
+
+    {
+        "addresses": [
+            "10.10.10.1/32"
+        ],
+        "device": 1,
+        "speed": 10000,
+        "networks": [
+            "10.10.10.0/24"
+        ],
+        "description": "this is eth0",
+        "name": "eth0",
+        "id": 1,
+        "parent_id": null,
+        "mac_address": null,
+        "attributes": {
+            "vlan": "100"
+        },
+        "type": 6
+    }
+
+Addresses
+~~~~~~~~~
+
+An address assignment to an Interface is represented by an *Assignment*
+relationship to a Network object.
+
+If a Network object for the desired IP address assignment does not exist at the
+time of assignment, one is created and set to the state ``assigned``.
+
+If a Network object already exists and is not in a "busy state", then it will
+be assigned to the Interface.
+
+Assignments
+~~~~~~~~~~~
+
+Assignments represent the relationship and constraints for a Network to be
+associated to an Interface.
+
+The following constraints are enforced:
+
+* An address may not be assigned to a to more than one Interface on any given
+  Device.
+* Only a Network containing a host address with a prefix of ``/32`` (IPv4) or
+  ``/128`` (IPv6) may be assigned to an address.
+
+Networks
+~~~~~~~~
+
+The networks for an Interface are the are read-only representation of the
+derived parent Network objects of any addresses assigned to an Interface.
 
 Changes
--------
+=======
 
 All Create/Update/Delete events are logged as a Change. A Change includes
 information such as the change time, user, and the full object payload after
@@ -80,23 +324,81 @@ modification.
 
 Changes are immutable and can only be removed by deleting the entire Site.
 
-Users
------
+A typical Change object might look like:
 
-Users are for logging into stuff. More on this later.
+.. code-block:: javascript
+
+    {
+        "event": "Create",
+        "change_at": 1460994054,
+        "resource_name": "Attribute",
+        "resource": {
+            "multi": false,
+            "resource_name": "Interface",
+            "description": "",
+            "required": false,
+            "site_id": 1,
+            "display": false,
+            "constraints": {
+                "pattern": "",
+                "valid_values": [],
+                "allow_empty": false
+            },
+            "id": 9,
+            "name": "foo"
+        },
+        "user": {
+            "id": 1,
+            "email": "admin@localhost"
+        },
+        "resource_id": 9,
+        "id": 36,
+        "site": {
+            "description": "This is a demonstration site for NSoT.",
+            "id": 1,
+            "name": "Demo Site"
+        }
+    }
+
+Users
+=====
+
+Users are for logging into stuff. Users in NSoT are represented by an email
+address.
+
+Users have a "secret key" that can be used for API authentication.
+
+A typical User might look like:
+
+.. code-block:: javascript
+
+    {
+        "id": 1,
+        "email": "admin@localhost",
+        "permissions": {
+            "1": {
+                "user_id": 1,
+                "site_id": 1,
+                "permissions": [
+                    "admin"
+                ]
+            }
+        }
+    }
 
 Permissions
------------
+===========
 
 Permissions, like other objects, are specific to Sites. There are no
 permissions that cross over sites. All objects are readable regardless
 of permissions. There is currently only one type of permissions a User
 can have in order to make modifications:
 
-    * admin
-        - Ability to Update/Delete Site
-        - Ability to grant permissions within a site
-        - All subsequent permissions
+* admin
+
+    + Ability to Update/Delete Site
+    + Ability to grant permissions within a site
+    + All subsequent permissions
 
 Site creation is open to all users. Upon creating a Site you become
 an admin of that Site with full permissions.

--- a/docs/support.rst
+++ b/docs/support.rst
@@ -1,6 +1,26 @@
 Support
 =======
 
-For the time being the best way to get support, provide feedback, ask
-questions, or to just talk shop is to find us on IRC at ``#nsot`` on Freenode
-(**irc://irc.freenode.net/nsot**).
+Network Source of Truth is a primarily a Pacific coast operation, so your best
+chance of getting a real-time response is during the weekdays, Pacific time.
+
+The best way to get support, provide feedback, ask questions, or to just talk
+shop is to find us online on Slack.
+
+We have a bi-direction Slack/IRC bridge for our channels so that users can use
+whichever they prefer.
+
+Slack
+-----
+
+We hangout on `Slack <https://slack.com>`_ on the `NetworkToCode
+<http://networktocode.com>`_ team.
+
+1. `Request to join the team <http://slack.networktocode.com>`_ (it's free!)
+2. Join us in ``#nsot``.
+
+IRC
+---
+
+If you want to keep it old school and use IRC, find us at ``#nsot`` on Freenode
+(irc://irc.freenode.net/nsot).

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -2,16 +2,59 @@
 Tutorial
 ########
 
-Here's how to use NSoT. There's not much here right now. For now do this:
+Here's how to use NSoT.
 
-1. Install `pynsot <https://pynsot.readthedocs.org>`_, the Python API client
-   and CLI utility:
+This document assumes that you've already have an instance of NSoT installed,
+configured, and running on your system. If you don't, please either check out
+the :doc:`quickstart` or head over to the full-blown :doc:`installation` guide
+and then return here.
 
-   .. code-block:: bash
+First Steps
+===========
 
-       $ pip install pynsot
+.. important::
+    Because this is a work-in-progress, we're going to use the command-line
+    utility provided by the official NSoT client to get you acquainted with
+    NSoT.
 
-2. Check out the :doc:`models`.
-3. Play with the :ref:`demo`.
+Install the Client
+------------------
 
-More detail coming soon!
+First things first, you'll need to install `pyNSoT
+<https://pynsot.readthedocs.org>`_, the official Python API client and CLI
+utility:
+
+.. code-block:: bash
+
+    $ pip install pynsot
+
+Configure the Client
+--------------------
+
+After you've installed the client, please follow the `pyNSoT Configuration
+<http://pynsot.readthedocs.org/en/latest/config.html>`_ guide to establish a
+``.pynsotrc`` file.
+
+Using the Command-Line
+======================
+
+Once you've got a working ``nsot`` CLI setup, please follow the `pyNSoT
+Command-Line <http://pynsot.readthedocs.org/en/latest/cli.html>`_ guide. This
+will get you familiarized with the basics of how NSoT works.
+
+Understanding the Data Model
+============================
+
+NSoT has a relatively simple data model, but the objects themselves can be
+quite sophisticated. Familiarize yourself with the :doc:`models`.
+
+Using the REST API
+==================
+
+Familiarize yourself with the basics of the :doc:`api/rest`.
+
+Administering the Server
+========================
+
+Familiarize with the ``nsot-server`` command that is used to manage your server
+instance by checking out the :doc:`admin` guide.


### PR DESCRIPTION
- Expanded the tutorial to refer to the pyNSoT docs to get hands-on w/
  the CLI, and added callouts for the other major sections of the nsot
  docs such as the data model, REST API, and server admin.
- Greatly expanded the data models doc w/ details about how each object
  works, how they releate to each other, and samples of what objects
  look like using the API.
- Added the ability to see the source code for documented Python code directly
  from the docs!
- Expand the support section to include Slack as the primary means of
  comm and included mention of the Slack/IRC bridge.
- Added sections for the browsable API and object schemas to the REST API docs
- Added attribution for the logo
- Added a "official client" section to the install docs