### PR TITLE
Fixes #197: bump.sh for OS X

### DIFF
--- a/bump.sh
+++ b/bump.sh
@@ -22,8 +22,8 @@ function proceed() {
 }
 
 function replace() {
-    sed -i '' "s/'${CURVER}'/'${VERSION}'/" nsot/version.py && \
-        echo "Updated nsot/version.py"
+    sed -i.bak "s/'${CURVER}'/'${VERSION}'/" nsot/version.py && \
+        echo "Updated nsot/version.py" && rm nsot/version.py.bak
 
     sed "s/{{ NSOT_VERSION }}/${VERSION}/" docker/Dockerfile.sub > \
         docker/Dockerfile && echo "Updated docker/Dockerfile"

--- a/bump.sh
+++ b/bump.sh
@@ -22,7 +22,7 @@ function proceed() {
 }
 
 function replace() {
-    sed -i "s/'${CURVER}'/'${VERSION}'/" nsot/version.py && \
+    sed -i '' "s/'${CURVER}'/'${VERSION}'/" nsot/version.py && \
         echo "Updated nsot/version.py"
 
     sed "s/{{ NSOT_VERSION }}/${VERSION}/" docker/Dockerfile.sub > \


### PR DESCRIPTION
```
  -i[SUFFIX], --in-place[=SUFFIX]
                 edit files in place (makes backup if SUFFIX supplied)
```

`sed` that is distributed with OS X, `SUFFIX` is not optional. Setting it to empty string should fix

(#197)