### PR TITLE
Working implementation of resthooks

### DIFF
--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -354,3 +354,80 @@ an error will be returned.
         }
     }
 
+Resthooks
+=========
+
+NSoT implements resthooks_ for subscribing to adds, changes, and removals of
+resource types. To do this, the hook needs to be created with a valid event
+name and target to receive the update
+
+.. _resthooks: http://resthooks.org/
+
+Event names are in the format of ``resource_name.action``. Current valid
+actions are:
+
+* ``added``
+* ``changed``
+* ``removed``
+
+Creating a hook:
+
+.. code-block:: http
+
+    POST /api/hooks/
+
+.. code-block:: javascript
+
+    {
+        "event": "network.added",
+        "target": "http://netwatcher.company.com"
+    }
+
+Checking details of a hook:
+
+.. code-block:: http
+
+    GET /api/hooks/:id
+
+.. code-block:: javascript
+
+    {
+        "id": 2,
+        "created": "2016-11-06T01:15:32.259000",
+        "updated": "2016-11-06T01:16:50.925442",
+        "event": "network.added",
+        "target": "http://localhost:8888",
+        "user": 1
+    }
+
+Payload target server can expect to receive:
+
+.. code-block:: http
+
+    POST /
+
+.. code-block:: javascript
+
+    {
+        "hook": {
+            "target": "http://localhost:8888",
+            "id": 2,
+            "event": "network.added"
+        },
+        "data": {
+            "parent_id": 6,
+            "state": "allocated",
+            "prefix_length": 16,
+            "is_ip": false,
+            "ip_version": "4",
+            "network_address": "192.168.0.0",
+            "attributes": {},
+            "site_id": 1,
+            "id": 7
+        }
+    }
+
+Things to note
+--------------
+
+* Pushes will not retry currently

--- a/nsot/api/serializers.py
+++ b/nsot/api/serializers.py
@@ -7,6 +7,7 @@ import logging
 from django.contrib.auth import get_user_model
 from rest_framework import fields, serializers
 from rest_framework_bulk import BulkSerializerMixin, BulkListSerializer
+from rest_hooks.models import Hook
 
 from . import auth
 from .. import exc, models, validators
@@ -523,3 +524,13 @@ class AuthTokenSerializer(serializers.Serializer):
         else:
             msg = 'Must include "email" and "secret_key"'
             raise exc.ValidationError(msg)
+
+
+#######
+# Hooks
+#######
+class HookSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Hook
+        fields = '__all__'
+        read_only_fields = ('user',)

--- a/nsot/api/urls.py
+++ b/nsot/api/urls.py
@@ -19,6 +19,7 @@ router.register(r'interfaces', views.InterfaceViewSet)
 router.register(r'networks', views.NetworkViewSet)
 router.register(r'users', views.UserViewSet)
 router.register(r'values', views.ValueViewSet)
+router.register(r'hooks', views.HookViewSet)
 
 # Nested router for resources under /sites
 sites_router = routers.BulkNestedRouter(

--- a/nsot/api/views.py
+++ b/nsot/api/views.py
@@ -10,6 +10,7 @@ from rest_framework.decorators import detail_route, list_route
 from rest_framework.response import Response
 from rest_framework_bulk import mixins as bulk_mixins
 from rest_framework_extensions.cache.decorators import cache_response
+from rest_hooks.models import Hook
 
 from . import auth, filters, serializers
 from .. import exc, models
@@ -723,3 +724,12 @@ class AuthTokenVerifyView(APIView):
                 ('data', True),
             ])
         )
+
+
+class HookViewSet(viewsets.ModelViewSet):
+    model = Hook
+    serializer_class = serializers.HookSerializer
+    queryset = Hook.objects.all()
+
+    def perform_create(self, serializer):
+        serializer.save(user=self.request.user)

--- a/nsot/conf/settings.py
+++ b/nsot/conf/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = (
     'smart_selects',
     'rest_framework',
     'rest_framework_swagger',
+    'rest_hooks',
     'custom_user',
     'nsot',
 )
@@ -425,7 +426,35 @@ HOST_PREFIXES = (32, 128)
 IP_VERSIONS = ('4', '6')
 
 # Whether to compress IPv6 for display purposes, for example:
-# - Exploded (default): 2620:0100:6000:0000:0000:0000:0000:0000/40 
+# - Exploded (default): 2620:0100:6000:0000:0000:0000:0000:0000/40
 # - Compressed: 2620:100:6000::/40
 # Default: True
 NSOT_COMPRESS_IPV6 = True
+
+#########
+# Hooks #
+#########
+# from nsot.util.core import hook_delivery
+
+# Map actual model action names to cosmetic event names
+# E.g: resource.added => will trigger for created action
+HOOK_ACTIONS = {
+    'create': 'added',
+    'update': 'changed',
+    'delete': 'removed',
+}
+HOOK_MODELS = [
+    'Attribute',
+    'Device',
+    'Interface',
+    'Network',
+    'Site',
+]
+# Map action to each model we want hook-ability for. Mapped to None because we
+# implement custom hooks on the Change model. Every NSoT change goes through
+# there so we trigger hooks on Change.save()
+HOOK_EVENTS = {
+    '{}.{}'.format(model.lower(), action): None
+    for model in HOOK_MODELS
+    for action in HOOK_ACTIONS.values()
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,6 @@ MarkupSafe==0.23
 netaddr==0.7.18
 PyYAML==3.11
 static3==0.6.1
+django-rest-hooks==1.3.1
+requests==2.11.1
+urllib3==1.19


### PR DESCRIPTION
The other PR had become **very** old and was using a fork of the real deal.

Events are created for each create, update, delete action on each resource. These events are published on-save for the Change model.

All hooks will be matched with the event and not the default "user who made change" -> "user's hooks". I think this makes sense due to the nature of an IPAM and assuming people will want to subscribe to all changes for a category, not just changes made by a specific user to the category.

There's no retrying here. We can always reiterate on that later but the framework doesn't implement it themselves. You can involve celery tasks to do it (as the authors want you to) or overload the delivery function and deal with making sure it's threaded/asyncio/otherwise non-blocking.

I've tested and they definitely work. Example of update for a hook for user `1` when the change was made by user `2`:

```javascript
{
  "hook": {
    "target": "http://localhost:8888/",
    "id": 9,
    "event": "network.changed"
  },
  "data": {
    "parent_id": null,
    "state": "assigned",
    "prefix_length": 24,
    "is_ip": false,
    "ip_version": "4",
    "network_address": "5.5.5.0",
    "attributes": {},
    "site_id": 1,
    "id": 9
  }
}

```

The NSoT tests are kind of hard to follow for implementing a new endpoint. Mostly because there are so many custom wrappers/utils and I'm not sure what I need to/should re-implement for the new one. Could use suggestions here.

My testing of the hooks was very easy via the API explorer.