### PR TITLE
Fix for issue #219

### DIFF
--- a/nsot/api/views.py
+++ b/nsot/api/views.py
@@ -192,6 +192,8 @@ class NsotViewSet(BaseNsotViewSet, viewsets.ModelViewSet):
             raise exc.ValidationError(err.message_dict)
         except exc.IntegrityError as err:
             raise exc.Conflict(err.message)
+        except exc.ObjectDoesNotExist as err:
+            raise exc.BadRequest("Site with id number %s does not exist"%self.kwargs['site_pk'])
         else:
             # This is so that we can always work w/ objects as a list
             if not isinstance(objects, list):

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ class SDistWithBuildStatic(SDistCommand):
 
 class BuildStatic(Command):
     user_options = []
-
+    description = 'builds all front end dependencies'
     def initialize_options(self):
         pass
 


### PR DESCRIPTION
Hi I was able to fix the issue. When the request to create a network in a non-existant site is sent, the `perform_create` method in class `NsotViewSet` gets called.  The line with `objects = serializer.save()` throws an `exc.ObjectDoesNotExist` exception because of the non-existant site. This exception is not handled and causes an internal server error, hence the 500 status code error and stacktrace.  To fix the issue,I catch the `exc.ObjectDoesNotExist` exception and raise a BadRequest exception instead which has the 400 status code. This status code  was requested by @jathanism in issue #219. 

Also, I am adding a description variable with a string value assigned in the BuildStatic class. Whenever you run **python setup.py --help-commands** you would see "(no description available)" next to the build_static option, which can be seen below.  

![nodescription](https://cloud.githubusercontent.com/assets/3707038/21487769/f4bec834-cba0-11e6-86c4-7259c9edbcdb.png)

With my changes you would see a description for build_static when you run **python setup.py --help-commands**, which can be see below

![description](https://cloud.githubusercontent.com/assets/3707038/21487794/36b5615c-cba2-11e6-94a7-d5854b3257f6.png)

The new description will be "builds all front end dependencies"