### PR TITLE
Move the Vagrantfile to the root of the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ nosetests.xml
 
 docs/_build
 .*sw?
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,6 +10,8 @@ Vagrant.configure(2) do |config|
   # For a complete reference, please see the online documentation at
   # https://docs.vagrantup.com.
 
+  config.vm.hostname = 'nsot-dev'
+
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
   config.vm.box = "hashicorp/precise32"
@@ -64,7 +66,7 @@ Vagrant.configure(2) do |config|
   # Enable provisioning with a shell script. Additional provisioners such as
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
   # documentation for more information about their specific syntax and use.
-   config.vm.provision "shell", inline: <<-SHELL
+  config.vm.provision "shell", inline: <<-SHELL
 export DEBIAN_FRONTEND=noninteractive
 sudo apt-get -y update
 sudo apt-get -y install build-essential python-dev libffi-dev libssl-dev

--- a/vagrant/README.rst
+++ b/vagrant/README.rst
@@ -2,8 +2,8 @@
 Vagrant
 #######
 
-The `Vagrantfile` in this directory creates a fresh Vagrant box running Ubuntu
-and NSoT.
+The `Vagrantfile` in the root of this repo creates a fresh Vagrant box running
+Ubuntu and NSoT.
 
 Prerequisites
 =============
@@ -27,7 +27,7 @@ To provision the virtual machine open a command prompt, and run the
 following command from this directory:
 
 .. code-block:: bash
-          
+
     $ vagrant up
 
 This will build a new Vagrant box, and pre-install NSoT for you.


### PR DESCRIPTION
Since by default Vagrant mounts the directory containing the Vagrantfile
as `/vagrant/` inside the VM, this gives us easier access to the code in
case we want to run NSoT via the code we're editing rather than via PyPI.

I also: 
* Added .vagrant to .gitignore since that folder is created by Vagrant
* Gave the VM a hostname to make it more clear you're inside a NSoT dev VM
* Included a couple of whitespace fixes that my editor helpfully made