### PR TITLE
Fix #230 - Correct typo in Network.descendants endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,10 +7,13 @@ Version History
 
 .. _v1.1:
 
-1.1 (2017-01-13)
+1.1 (2017-01-18)
 ----------------
 
-* Implementation of Circuits as a resource object.
+* A formal :ref:`deprecation-policy` has been implemented which dictates a
+  three-feature release cycle for removing deprecated API endpoints. Please see
+  the documentation on this topic for more details.
+* Fix #203 - Implementation of Circuits as a resource object.
 
   + A Circuit has one-to-one relationship with each of A and Z side
     endpoint Interfaces.
@@ -26,13 +29,15 @@ Version History
   + ``circuits/:id/interfaces/`` - List interfaces bound to the circuit
   + ``circuits/:id/addresses/`` - List addresses bound to circuit interfaces
 
-* The Interface object unicode representation changed to
-  ``device_hostname:name`` so that it can more easily be used as a slug for
-  computing Circuit slug.
 * Interfaces have a new ``interfaces/:id/circuit/`` detail route that will
   display the circuit to which an interface is bound.
 * Devices have a new ``devices/:id/circuits/`` detail route that will
   display all circuits bound to interfaces on the device.
+* Fix #191 - The Interface object unicode representation changed to
+  ``device_hostname:name`` so that it can more easily be used as a slug for
+  computing Circuit slug.
+* Fix #230 - The misspelled ``networks/:id/descendents/`` API endpoint is
+  pending deprecation in exchange for ``networks/:id/descendants/``.
 
 .. _v1.0.13:
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -161,3 +161,56 @@ We make use of bower's "main file" concept to distribute only "main" files.
 Most packages don't consider consider the minified versions of their project to
 be their main files so you'll likely also need to update the ``overrides``
 section of ``bower.json`` with which files to distribute.
+
+.. _versioning:
+
+Versioning
+----------
+
+We use `semantic versioning <http://semver.org>`_. Version numbers will
+follow this format::
+
+    Major version}.{Minor version}.{Revision number}.{Build number (optional)}
+
+Patch version numbers (0.0.x) are used for changes that are API compatible. You
+should be able to upgrade between minor point releases without any other code
+changes.
+
+Minor version numbers (0.x.0) may include API changes, in line with the
+:ref:`deprecation-policy`. You should read the release notes carefully before
+upgrading between minor point releases.
+
+Major version numbers (x.0.0) are reserved for substantial project milestones.
+
+.. _deprecation-policy:
+
+Deprecation policy
+------------------
+
+NSoT releases follow a formal deprecation policy, which is in line with
+`Django's deprecation policy <https://docs.djangoproject.com/en/stable/internals/release-process/#internal-release-deprecation-policy>`_.
+
+The timeline for deprecation of a feature present in version 1.0 would work as follows:
+
+* Version 1.1 would remain **fully backwards compatible** with 1.0, but would raise
+  Python ``PendingDeprecationWarning`` warnings if you use the feature that are
+  due to be deprecated. These warnings are **silent by default**, but can be
+  explicitly enabled when you're ready to start migrating any required changes.
+
+  Additionally, a ``WARN`` message will be logged to standard out from the
+  ``nsot-server`` process. 
+
+  Finally, a ``Warning`` header will be sent back in any response from the API.
+  For example::
+
+    Warning: 299 - "The `descendents` API endpoint is pending deprecation. Use
+    the `descendants` API endpoint instead."
+
+* Version 1.2 would escalate the Python warnings to ``DeprecationWarning``,
+  which is **loud by default**.
+* Version 1.3 would remove the deprecated bits of API entirely and accessing
+  any deprecated API endoints will result in a ``404`` error. 
+
+Note that in line with Django's policy, any parts of the framework not
+mentioned in the documentation should generally be considered private API, and
+may be subject to change.

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -247,6 +247,11 @@ children
     The child networks of this network
 
 descendents
+    .. deprecated:: 1.1
+    Use *descendants* instead, which is the correctly spelled version of the
+    same method.
+
+descendants
     All children of the children of this network
 
 closest_parent

--- a/nsot/models.py
+++ b/nsot/models.py
@@ -868,7 +868,7 @@ class Network(Resource):
             subnets = cidr.subnets(new_prefix=prefix_length)
 
         # Exclude children that are in busy states.
-        children = self.get_descendents()
+        children = self.get_descendants()
 
         # Partition children into busy children and all children, storing
         # the `.ip_network` property up front.
@@ -1015,7 +1015,7 @@ class Network(Resource):
             'network_address', 'prefix_length'
         )
 
-    def get_descendents(self):
+    def get_descendants(self):
         """Return all of my children!"""
         return self.subnets(include_ips=True).order_by(
             'network_address', 'prefix_length'
@@ -1552,9 +1552,9 @@ class Circuit(Resource):
 
     class Meta:
         # TODO(jathan): Benchmark queries on a large database to identify
-        # whether we need explicit indices for this model. In my initial testing
-        # all of the common lookup fields are already indexed so this may not be
-        # necessary.
+        # whether we need explicit indices for this model. In my initial
+        # testing all of the common lookup fields are already indexed so this
+        # may not be necessary.
         '''
         index_together = [
             ('endpoint_a', 'endpoint_z'),

--- a/nsot/util/stats.py
+++ b/nsot/util/stats.py
@@ -12,13 +12,13 @@ __all__ = ('calculate_network_utilization', 'get_network_utilization')
 
 def calculate_network_utilization(parent, hosts, as_string=False):
     """
-    Calculate utilization for a network and its descendents.
+    Calculate utilization for a network and its descendants.
 
     :param parent:
         The parent network
 
     :param hosts:
-        List of host IPs descendent from parent
+        List of host IPs descendant from parent
 
     :param as_string:
         Whether to return stats as a string
@@ -57,5 +57,5 @@ def get_network_utilization(network, as_string=False):
     :param as_string:
         Whether to return stats as a string
     """
-    descendents = network.get_descendents().filter(is_ip=True)
-    return calculate_network_utilization(network, descendents, as_string)
+    descendants = network.get_descendants().filter(is_ip=True)
+    return calculate_network_utilization(network, descendants, as_string)

--- a/tests/api_tests/test_networks.py
+++ b/tests/api_tests/test_networks.py
@@ -437,7 +437,7 @@ def test_deletion(site, client):
 
 
 def test_mptt_detail_routes(site, client):
-    """Test detail routes for ancestor/children/descendents/root methods."""
+    """Test detail routes for ancestor/children/descendants/root methods."""
     net_uri = site.list_uri('network')
 
     client.create(net_uri, cidr='10.0.0.0/8')
@@ -496,28 +496,36 @@ def test_mptt_detail_routes(site, client):
     assert_success(client.retrieve(uri), expected)
     assert_success(client.retrieve(natural_uri), expected)
 
-    # descendents
-    uri = reverse('network-descendents', args=(site.id, net_8['id']))
-    natural_uri = reverse('network-descendents', args=(site.id, mkcidr(net_8)))
+    # descendants (spelled correctly)
+    uri = reverse('network-descendants', args=(site.id, net_8['id']))
+    natural_uri = reverse('network-descendants', args=(site.id, mkcidr(net_8)))
     wanted = [net_12, net_14, net_25, ip1, ip2]
     expected = wanted
     assert_success(client.retrieve(uri), expected)
     assert_success(client.retrieve(natural_uri), expected)
 
-    uri = reverse('network-descendents', args=(site.id, net_14['id']))
+    uri = reverse('network-descendants', args=(site.id, net_14['id']))
     natural_uri = reverse(
-        'network-descendents', args=(site.id, mkcidr(net_14))
+        'network-descendants', args=(site.id, mkcidr(net_14))
     )
     wanted = [net_25, ip1, ip2]
     expected = wanted
     assert_success(client.retrieve(uri), expected)
     assert_success(client.retrieve(natural_uri), expected)
 
-    uri = reverse('network-descendents', args=(site.id, ip2['id']))
-    natural_uri = reverse('network-descendents', args=(site.id, mkcidr(ip2)))
+    uri = reverse('network-descendants', args=(site.id, ip2['id']))
+    natural_uri = reverse('network-descendants', args=(site.id, mkcidr(ip2)))
     expected = []
     assert_success(client.retrieve(uri), expected)
     assert_success(client.retrieve(natural_uri), expected)
+
+    # descendents (spelled incorrectly) should send along a "Warning" header
+    # TODO(jathan): This should be removed no earlier than v1.3 release.
+    uri = reverse('network-descendents', args=(site.id, net_14['id']))
+    expected = [net_25, ip1, ip2]
+    response = client.retrieve(uri)
+    assert_success(response, expected)
+    assert response.headers.get('Warning') is not None
 
     # parent
     uri = reverse('network-parent', args=(site.id, ip2['id']))

--- a/tests/model_tests/test_networks.py
+++ b/tests/model_tests/test_networks.py
@@ -177,7 +177,7 @@ def test_retrieve_networks(site):
 
 
 def test_mptt_methods(site):
-    """Test ancestor/children/descendents/root model methods."""
+    """Test ancestor/children/descendants/root model methods."""
     net_8 = models.Network.objects.create(site=site, cidr=u'10.0.0.0/8')
     net_12 = models.Network.objects.create(site=site, cidr=u'10.16.0.0/12')
     net_14 = models.Network.objects.create(site=site, cidr=u'10.16.0.0/14')
@@ -209,10 +209,10 @@ def test_mptt_methods(site):
     assert list(net_25.get_children()) == [ip1, ip2]
     assert list(net_12.get_children()) == [net_14]
 
-    # get_descendents()
-    assert list(net_8.get_descendents()) == [net_12, net_14, net_25, ip1, ip2]
-    assert list(net_14.get_descendents()) == [net_25, ip1, ip2]
-    assert list(ip2.get_descendents()) == []
+    # get_descendants()
+    assert list(net_8.get_descendants()) == [net_12, net_14, net_25, ip1, ip2]
+    assert list(net_14.get_descendants()) == [net_25, ip1, ip2]
+    assert list(ip2.get_descendants()) == []
 
     # get_root()
     assert ip1.get_root() == net_8


### PR DESCRIPTION
- The API endpoint for `Network.descendents` will now emit a "Warning"
  header to clients calling that endpoint telling them that it is
  pending deprecation.
- Implemented 3-feature-release deprecation policy in the documentation.
- Updated and improved some docstrings in the code
- Fixed a couple of pep8 style inconsistencies
- All of the unit tests updated for Great Justice™