### PR TITLE
Allow for slashes in Circuit API URLs

### DIFF
--- a/nsot/api/views.py
+++ b/nsot/api/views.py
@@ -718,7 +718,7 @@ class CircuitViewSet(ResourceViewSet):
     # end with 'None' (as is the case of a circuit without a Z side), or simply
     # not end with a letter (assuming that subcommands will always end with a
     # letter).
-    lookup_value_regex = '(?:.+(?:None|[^a-zA-Z]))|(?:[^\/]+)'
+    lookup_value_regex = '.+(?:None|[^a-zA-Z])|[^\/]+'
 
     # TODO(jathan): Revisit this if and when we upgrade or replace
     # django-rest-framework-bulk==0.2.1

--- a/nsot/models.py
+++ b/nsot/models.py
@@ -1604,6 +1604,17 @@ class Circuit(Resource):
 
     def clean_name(self, value):
         if value:
+            # Disallow / or . in names since we use the name as the natural key and
+            # including those will screw with URLs
+            disallowed_chars = set(['.', '/'])
+
+            if len(set(value) & disallowed_chars) != 0:
+                raise exc.ValidationError({
+                    'name': 'Circuit name cannot contain any of: {}'.format(
+                        ', '.join(disallowed_chars)
+                    )
+                })
+
             return value
 
         # Add display name of hostname:intf_hostname:intf

--- a/nsot/models.py
+++ b/nsot/models.py
@@ -1604,8 +1604,8 @@ class Circuit(Resource):
 
     def clean_name(self, value):
         if value:
-            # Disallow / or . in names since we use the name as the natural key and
-            # including those will screw with URLs
+            # Disallow / or . in names since we use the name as the natural key
+            # and including those will screw with URLs
             disallowed_chars = set(['.', '/'])
 
             if len(set(value) & disallowed_chars) != 0:

--- a/tests/api_tests/test_circuits.py
+++ b/tests/api_tests/test_circuits.py
@@ -7,7 +7,7 @@ import pytest
 pytestmark = pytest.mark.django_db
 
 import copy
-from django.core.urlresolvers import reverse
+from django.core.urlresolvers import reverse, resolve
 import json
 import logging
 from rest_framework import status
@@ -636,3 +636,25 @@ def test_detail_routes(site, client):
     ifc_circuit_uri = reverse('interface-circuit', args=(site.id, if_a['id']))
     expected = cir
     assert_success(client.retrieve(ifc_circuit_uri), expected)
+
+    # Test to make sure routes work correctly with a myriad of natural keys
+    test_uri = '/api/circuits/{0}/devices/'
+    test_ids = [
+        # Some PK IDs
+        '1',
+        '5000',
+
+        # User-given name
+        'foo-bar_baz',
+
+        # Auto-generated name with no Z side
+        'foo-bar01:Ethernet1/2_None',
+
+        # Normal auto-generated names
+        'foo-bar01:Ethernet9_foo-bar02:Ethernet7',
+        'foo-bar1:xe-0/0/0.0_foo-bar2:xe-0/0/0.0',
+    ]
+
+    for test_id in test_ids:
+        result = resolve(test_uri.format(test_id))
+        assert result.url_name == 'circuit-devices'


### PR DESCRIPTION
This adds a `lookup_value_regex` to `CircuitViewSet` to allow for slashes in the URLs, since lookups by natural key could contain these characters as part of the Interface natural keys that make up the default name for Circuits. 

The approach I took to this is similar to how @dmar42 did Interfaces: If a slash exists in the Circuit lookup key, ensure that the key does not end in a letter or otherwise it's likely a detail route.

To avoid issues with user-supplied names, I also added logic to raise a validation error if the name contains a period or slash.

This is all to fix a bug I found while implementing the CLI stuff for Circuits (PR on pynsot coming for that very soon!)