### PR TITLE
Need to change requirements.txt to use django-smart-selects==1.2.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ django-filter>=0.15.3,<0.16.0
 django-jinja==1.4.1
 django-macaddress==1.3.2
 django-rest-swagger==0.3.5
-django-smart-selects==1.1.1
+django-smart-selects==1.2.9
 djangorestframework>=3.5.0,<3.6.0
 djangorestframework-bulk==0.2.1
 drf-extensions==0.2.8


### PR DESCRIPTION
There is a security vulnerability with versions less than 1.2.9. More information can be found at 
 digi604/django-smart-selects#171