### PR TITLE
Fix #223: Enhance Network "get_next" methods to optionally allocate/reserve at the same time

### DIFF
--- a/nsot/models.py
+++ b/nsot/models.py
@@ -1410,10 +1410,9 @@ class Interface(Resource):
         p = self.parent
         ancestors = []
         while p is not None:
-            ancestors.append(p)
+            ancestors.append(p.id)
             p = p.parent
-        ancestor_ids = [a.id for a in ancestors]
-        return Interface.objects.filter(id__in=ancestor_ids)
+        return Interface.objects.filter(id__in=ancestors)
 
     def get_children(self):
         """Return the immediate children of an Interface."""
@@ -1425,11 +1424,10 @@ class Interface(Resource):
         descendants = []
         while len(s) > 0:
             top = s.pop()
-            descendants.append(top)
+            descendants.append(top.id)
             for c in top.get_children():
                 s.append(c)
-        descendant_ids = [c.id for c in descendants]
-        return Interface.objects.filter(id__in=descendant_ids)
+        return Interface.objects.filter(id__in=descendants)
 
     def get_root(self):
         """Return the parent of all ancestors of an Interface."""

--- a/nsot/models.py
+++ b/nsot/models.py
@@ -831,6 +831,8 @@ class Network(Resource):
         """
         start_time = time.time()  # For debugging
 
+        log.debug('Allocation type is %s'% ('strict' if strict else 'loose'))        
+
         # If we're reserved, automatically ZILCH!!
         # TODO(jathan): Should we raise an error instead?
         if self.state == Network.RESERVED:

--- a/nsot/models.py
+++ b/nsot/models.py
@@ -719,7 +719,7 @@ class Network(Resource):
         choices=IP_VERSION_CHOICES
     )
     is_ip = models.BooleanField(
-        null=False, default=False, db_index=True,
+        null=False, default=False, db_index=True, editable=False,
         help_text='Whether the Network is a host address or not.'
     )
     site = models.ForeignKey(
@@ -830,8 +830,6 @@ class Network(Resource):
             list(IPNetwork)
         """
         start_time = time.time()  # For debugging
-
-        log.debug('Allocation type is %s'% ('strict' if strict else 'loose'))        
 
         # If we're reserved, automatically ZILCH!!
         # TODO(jathan): Should we raise an error instead?

--- a/tests/model_tests/test_networks.py
+++ b/tests/model_tests/test_networks.py
@@ -377,5 +377,3 @@ def test_strict_allocation_3(site):
     child = models.Network.objects.create(site = site, cidr = u'2001:db8:abcd:0012::0/97')
     expected = [ipaddress.ip_network(u'2001:db8:abcd:12::8000:0/128')]
     assert parent.get_next_network(128, strict = True) == expected
-
-    

--- a/tests/model_tests/test_networks.py
+++ b/tests/model_tests/test_networks.py
@@ -376,4 +376,6 @@ def test_strict_allocation_3(site):
     parent = models.Network.objects.create(site = site, cidr = u'2001:db8:abcd:0012::0/96')
     child = models.Network.objects.create(site = site, cidr = u'2001:db8:abcd:0012::0/97')
     expected = [ipaddress.ip_network(u'2001:db8:abcd:12::8000:0/128')]
-    assert parent.get_next_network(128, strict = True) == expected 
+    assert parent.get_next_network(128, strict = True) == expected
+
+    


### PR DESCRIPTION
Users can send a post request to `next_network` and `next_address` actions. If it is a post request then the action will get the networks or addresses and then save them as network objects in the database as `allocated`. If the user sends the `reserve` flag and sets it as true, then it will be saved in the `reserved` state.
