### PR TITLE
Updated Vagrantfile to get box to come up and install nsot properly.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -71,6 +71,9 @@ export DEBIAN_FRONTEND=noninteractive
 sudo apt-get -y update
 sudo apt-get -y install build-essential python-dev libffi-dev libssl-dev
 sudo apt-get -y install python-pip
+sudo pip install --upgrade pip
+sudo pip install requests[security]
+sudo pip install --upgrade setuptools
 sudo pip install nsot mrproxy
 mkdir /home/vagrant/.nsot
 nsot-server init /home/vagrant/.nsot/nsot.conf.py


### PR DESCRIPTION
I am currently running the latest version of Vagrant and VirtualBox and am seeing this behavior on both Windows and Mac.

When running `vagrant up` I receive an error and nsot is not installed (see attached file).  

It looks to be an issue with the version of pip installed along with an outdated version of setuptools.

I updated the Vagrantfile to include these updates.  If there is another way to do this please let me know.  I created this PR just to show what I had to do to get vagrant to come up.  It is running clean now.

[NSOT-Vagrant-Error.txt](https://github.com/dropbox/nsot/files/812067/NSOT-Vagrant-Error.txt)
