### PR TITLE
Interface Tree traversal

### DIFF
--- a/nsot/api/views.py
+++ b/nsot/api/views.py
@@ -689,8 +689,12 @@ class InterfaceViewSet(ResourceViewSet):
     def parent(self, request, pk=None, site_pk=None, *args, **kwargs):
         """Return parent of interface"""
         interface = self.get_resource_object(pk, site_pk)
-        parent = [] if interface.parent is None else [interface.parent]
-        return self.list(request, queryset=parent, *args, **kwargs)
+        parent = interface.parent
+        if parent is not None:
+            pk = interface.parent_id
+        else:
+            pk = None
+        return self.retrieve(request, pk, site_pk, *args, **kwargs)
 
     @detail_route(methods=['get'])
     def ancestors(self, request, pk=None, site_pk=None, *args, **kwargs):
@@ -716,7 +720,9 @@ class InterfaceViewSet(ResourceViewSet):
     @detail_route(methods=['get'])
     def root(self, request, pk=None, site_pk=None, *args, **kwargs):
         interface = self.get_resource_object(pk, site_pk)
-        return self.list(request, queryset=interface.get_root(), *args, **kwargs)
+        root = interface.get_root()
+        pk = root.id
+        return self.retrieve(request, pk, site_pk, *args, **kwargs)
 
     @detail_route(methods=['get'])
     def circuit(self, request, pk=None, site_pk=None, *args, **kwargs):

--- a/nsot/api/views.py
+++ b/nsot/api/views.py
@@ -670,7 +670,6 @@ class InterfaceViewSet(ResourceViewSet):
         """Return a list of addresses for this Interface."""
         interface = self.get_resource_object(pk, site_pk)
         addresses = interface.addresses.all()
-
         return self.list(request, queryset=addresses, *args, **kwargs)
 
     @detail_route(methods=['get'])
@@ -678,14 +677,12 @@ class InterfaceViewSet(ResourceViewSet):
         """Return a list of information about my assigned addresses."""
         interface = self.get_resource_object(pk, site_pk)
         assignments = interface.assignments.all()
-
         return self.list(request, queryset=assignments, *args, **kwargs)
 
     @detail_route(methods=['get'])
     def networks(self, request, pk=None, site_pk=None, *args, **kwargs):
         """Return all the containing Networks for my assigned addresses."""
         interface = self.get_resource_object(pk, site_pk)
-
         return self.list(request, queryset=interface.networks, *args, **kwargs)
 
     @detail_route(methods=['get'])
@@ -693,7 +690,6 @@ class InterfaceViewSet(ResourceViewSet):
         """Return parent of interface"""
         interface = self.get_resource_object(pk, site_pk)
         parent = [] if interface.parent is None else [interface.parent]
-
         return self.list(request, queryset=parent, *args, **kwargs)
 
     @detail_route(methods=['get'])

--- a/nsot/api/views.py
+++ b/nsot/api/views.py
@@ -662,7 +662,6 @@ class InterfaceViewSet(ResourceViewSet):
             return serializers.InterfaceUpdateSerializer
         if self.request.method == 'PATCH':
             return serializers.InterfacePartialUpdateSerializer
-
         return self.serializer_class
 
     @detail_route(methods=['get'])

--- a/nsot/api/views.py
+++ b/nsot/api/views.py
@@ -686,7 +686,7 @@ class InterfaceViewSet(ResourceViewSet):
 
     @detail_route(methods=['get'])
     def parent(self, request, pk=None, site_pk=None, *args, **kwargs):
-        """Return parent of interface"""
+        """Return the parent of this Interface."""
         interface = self.get_resource_object(pk, site_pk)
         parent = interface.parent
         if parent is not None:
@@ -697,27 +697,31 @@ class InterfaceViewSet(ResourceViewSet):
 
     @detail_route(methods=['get'])
     def ancestors(self, request, pk=None, site_pk=None, *args, **kwargs):
-        """Return all ancestors of interface"""
+        """Return all the ancestors of this Interface."""
         interface = self.get_resource_object(pk, site_pk)
         return self.list(request, queryset=interface.get_ancestors(), *args, **kwargs)
 
     @detail_route(methods=['get'])
     def children(self, request, pk=None, site_pk=None, *args, **kwargs):
+        """Return all the children of this Interface."""
         interface = self.get_resource_object(pk, site_pk)
         return self.list(request, queryset=interface.get_children(), *args, **kwargs)
 
     @detail_route(methods=['get'])
     def descendants(self, request, pk=None, site_pk=None, *args, **kwargs):
+        """Return all the descendants of this Interface."""
         interface = self.get_resource_object(pk, site_pk)
         return self.list(request, queryset=interface.get_descendants(), *args, **kwargs)
 
     @detail_route(methods=['get'])
     def siblings(self, request, pk=None, site_pk=None, *args, **kwargs):
+        """Return all the siblings of this Interface."""
         interface = self.get_resource_object(pk, site_pk)
         return self.list(request, queryset=interface.get_siblings(), *args, **kwargs)
 
     @detail_route(methods=['get'])
     def root(self, request, pk=None, site_pk=None, *args, **kwargs):
+        """Return the root of the tree this Interface is part of."""
         interface = self.get_resource_object(pk, site_pk)
         root = interface.get_root()
         pk = root.id

--- a/nsot/api/views.py
+++ b/nsot/api/views.py
@@ -689,6 +689,40 @@ class InterfaceViewSet(ResourceViewSet):
         return self.list(request, queryset=interface.networks, *args, **kwargs)
 
     @detail_route(methods=['get'])
+    def parent(self, request, pk=None, site_pk=None, *args, **kwargs):
+        """Return parent of interface"""
+        interface = self.get_resource_object(pk, site_pk)
+        parent = [] if interface.parent is None else [interface.parent]
+
+        return self.list(request, queryset=parent, *args, **kwargs)
+
+    @detail_route(methods=['get'])
+    def ancestors(self, request, pk=None, site_pk=None, *args, **kwargs):
+        """Return all ancestors of interface"""
+        interface = self.get_resource_object(pk, site_pk)
+        return self.list(request, queryset=interface.get_ancestors(), *args, **kwargs)
+
+    @detail_route(methods=['get'])
+    def children(self, request, pk=None, site_pk=None, *args, **kwargs):
+        interface = self.get_resource_object(pk, site_pk)
+        return self.list(request, queryset=interface.get_children(), *args, **kwargs)
+
+    @detail_route(methods=['get'])
+    def descendants(self, request, pk=None, site_pk=None, *args, **kwargs):
+        interface = self.get_resource_object(pk, site_pk)
+        return self.list(request, queryset=interface.get_descendants(), *args, **kwargs)
+
+    @detail_route(methods=['get'])
+    def siblings(self, request, pk=None, site_pk=None, *args, **kwargs):
+        interface = self.get_resource_object(pk, site_pk)
+        return self.list(request, queryset=interface.get_siblings(), *args, **kwargs)
+
+    @detail_route(methods=['get'])
+    def root(self, request, pk=None, site_pk=None, *args, **kwargs):
+        interface = self.get_resource_object(pk, site_pk)
+        return self.list(request, queryset=interface.get_root(), *args, **kwargs)
+
+    @detail_route(methods=['get'])
     def circuit(self, request, pk=None, site_pk=None, *args, **kwargs):
         """Return the Circuit I am associated with"""
         interface = self.get_resource_object(pk, site_pk)

--- a/nsot/api/views.py
+++ b/nsot/api/views.py
@@ -703,7 +703,7 @@ class InterfaceViewSet(ResourceViewSet):
 
     @detail_route(methods=['get'])
     def children(self, request, pk=None, site_pk=None, *args, **kwargs):
-        """Return all the children of this Interface."""
+        """Return all the immediate children of this Interface."""
         interface = self.get_resource_object(pk, site_pk)
         return self.list(request, queryset=interface.get_children(), *args, **kwargs)
 

--- a/nsot/models.py
+++ b/nsot/models.py
@@ -1422,14 +1422,14 @@ class Interface(Resource):
 
     def get_root(self):
         """Return the parent of all ancestors of an interface"""
-        root = self.parent
-        while root is not None and root.parent is not None:
+        root = self
+        while root.parent is not None:
             root = root.parent
-        return [] if root is None else [root]
+        return root
 
     def get_siblings(self):
         """Return the interfaces with same parent as an interface"""
-        return list(Interface.objects.filter(parent=self.parent).exclude(id=self.id))
+        return list(Interface.objects.filter(parent=self.parent, device=self.device).exclude(id=self.id))
 
     def get_assignments(self):
         """Return a list of information about my assigned addresses."""

--- a/nsot/models.py
+++ b/nsot/models.py
@@ -1397,38 +1397,40 @@ class Interface(Resource):
         self.clean_addresses()
 
     def get_ancestors(self):
-        """Recursively get all parents of an interface"""
+        """Return all ancestors of an Interface."""
         p = self.parent
         ancestors = []
         while p is not None:
             ancestors.append(p)
             p = p.parent
-        return ancestors
+        ancestor_ids = [a.id for a in ancestors]
+        return Interface.objects.filter(id__in=ancestor_ids)
 
     def get_children(self):
-        """Return the immediate children of an interface"""
+        """Return the immediate children of an Interface."""
         return Interface.objects.filter(parent=self)
 
     def get_descendants(self):
-        """Recursively return all the children of an interface"""
+        """Return all the descendants of an Interface."""
         s = list(self.get_children())
-        children = []
+        descendants = []
         while len(s) > 0:
             top = s.pop()
-            children.append(top)
+            descendants.append(top)
             for c in top.get_children():
                 s.append(c)
-        return children
+        descendant_ids = [c.id for c in descendants]
+        return Interface.objects.filter(id__in=descendant_ids)
 
     def get_root(self):
-        """Return the parent of all ancestors of an interface"""
+        """Return the parent of all ancestors of an Interface."""
         root = self
         while root.parent is not None:
             root = root.parent
         return root
 
     def get_siblings(self):
-        """Return the interfaces with same parent as an interface"""
+        """Return Interfaces with the same parent and device id as an Interface."""
         return Interface.objects.filter(parent=self.parent, device=self.device).exclude(id=self.id)
 
     def get_assignments(self):

--- a/nsot/models.py
+++ b/nsot/models.py
@@ -1429,7 +1429,7 @@ class Interface(Resource):
 
     def get_siblings(self):
         """Return the interfaces with same parent as an interface"""
-        return list(Interface.objects.filter(parent=self.parent, device=self.device).exclude(id=self.id))
+        return Interface.objects.filter(parent=self.parent, device=self.device).exclude(id=self.id)
 
     def get_assignments(self):
         """Return a list of information about my assigned addresses."""
@@ -1513,7 +1513,7 @@ class Interface(Resource):
             return parent
         if parent.device_hostname != self.device_hostname:
             raise exc.ValidationError({
-                'parent': 'Parent\'s device does not match device with host name \"%s\"'%(self.device_hostname)
+                'parent': "Parent's device does not match device with host name %r"%self.device_hostname
             })
         return parent
 

--- a/nsot/models.py
+++ b/nsot/models.py
@@ -1508,6 +1508,16 @@ class Interface(Resource):
         """Extract hostname from device"""
         return device.hostname
 
+    def clean_parent(self, parent):
+        if parent is None:
+            return parent
+        if parent.device_hostname != self.device_hostname:
+            raise exc.ValidationError({
+                'parent': 'Parent\'s device does not match device with host name \"%s\"'%(self.device_hostname)
+            })
+        return parent
+
+
     def clean_fields(self, exclude=None):
         self.site_id = self.clean_site(self.site_id)
         self.name = self.clean_name(self.name)
@@ -1515,6 +1525,8 @@ class Interface(Resource):
         self.speed = self.clean_speed(self.speed)
         self.mac_address = self.clean_mac_address(self.mac_address)
         self.device_hostname = self.clean_device_hostname(self.device)
+        self.parent = self.clean_parent(self.parent)
+
 
     def save(self, *args, **kwargs):
         # We don't want to validate unique because we want the IntegrityError

--- a/tests/api_tests/test_interfaces.py
+++ b/tests/api_tests/test_interfaces.py
@@ -91,6 +91,9 @@ def test_tree_traversal(site, client):
     dev_resp = client.create(dev_uri, hostname='foo-bar1')
     dev = get_result(dev_resp)
 
+    dev_resp1 = client.create(dev_uri, hostname='foo-bar2')
+    dev1 = get_result(dev_resp1)
+
     ifc1_resp = client.create(
         ifc_uri, device=dev['id'], name='eth0', parent_id=None,
         mac_address=None,
@@ -141,6 +144,26 @@ def test_tree_traversal(site, client):
 
     assert_created(ifc5_resp, ifc5_obj_uri)
 
+    ifc6_resp = client.create(
+        ifc_uri, device = dev1['id'], name='eth0.4', parent_id=None,
+        mac_address = None
+    )
+
+    ifc6 = get_result(ifc6_resp)
+    ifc6_obj_uri = site.detail_uri('interface', id = ifc6['id'])
+
+    assert_created(ifc6_resp, ifc6_obj_uri)
+
+    ifc7_resp = client.create(
+        ifc_uri, device = dev1['id'], name='eth0.5', parent_id=None,
+        mac_address = None
+    )
+
+    ifc7 = get_result(ifc7_resp)
+    ifc7_obj_uri = site.detail_uri('interface', id = ifc7['id'])
+
+    assert_created(ifc7_resp, ifc7_obj_uri)
+
     # test Ancestors by calling it on ifc3
     expected = [ifc1, ifc2]
     uri = reverse('interface-ancestors', args = (site.id, ifc3['id']))
@@ -166,10 +189,22 @@ def test_tree_traversal(site, client):
     uri = reverse('interface-root', args=(site.id, ifc4['id']))
     assert_success(client.retrieve(uri), expected)
 
+    # test that root of ifc1 is ifc1
+    expected = ifc1
+    uri = reverse('interface-root', args=(site.id, ifc1['id']))
+    assert_success(client.retrieve(uri), expected)
+
     # test parent by calling it on ifc5
     expected = ifc2
     uri = reverse('interface-parent', args=(site.id, ifc5['id']))
     assert_success(client.retrieve(uri), expected)
+
+    # test sibling for interfaces with None as parent and attached
+    # to different devices
+    expected = [ifc7]
+    uri = reverse('interface-siblings', args=(site.id, ifc6['id']))
+    assert_success(client.retrieve(uri), expected)
+
 
 
 def test_creation_with_addresses(site, client):

--- a/tests/api_tests/test_interfaces.py
+++ b/tests/api_tests/test_interfaces.py
@@ -31,6 +31,9 @@ def test_creation(site, client):
     dev_resp = client.create(dev_uri, hostname='foo-bar1')
     dev = get_result(dev_resp)
 
+    dev_resp1 = client.create(dev_uri, hostname='foo-bar2')
+    dev1 = get_result(dev_resp1)
+
     net_resp = client.create(net_uri, cidr='10.1.1.0/24')
     net = get_result(net_resp)
 
@@ -55,6 +58,13 @@ def test_creation(site, client):
     ifc1_obj_uri = site.detail_uri('interface', id=ifc1['id'])
 
     assert_created(ifc1_resp, ifc1_obj_uri)
+
+    # Verify that creating a device with parent as
+    # ifc1 but device as foo-bar2 will cause error
+    assert_error(
+        client.create(ifc_uri, device=dev1['id'], name='eth0.1', parent_id=ifc1['id']),
+        status.HTTP_400_BAD_REQUEST
+    )
 
     # Make sure MAC is None
     assert ifc1['mac_address'] is None
@@ -199,12 +209,10 @@ def test_tree_traversal(site, client):
     uri = reverse('interface-parent', args=(site.id, ifc5['id']))
     assert_success(client.retrieve(uri), expected)
 
-    # test sibling for interfaces with None as parent and attached
-    # to different devices
+    # test sibling for interfaces with None as parent and attached to different devices
     expected = [ifc7]
     uri = reverse('interface-siblings', args=(site.id, ifc6['id']))
     assert_success(client.retrieve(uri), expected)
-
 
 
 def test_creation_with_addresses(site, client):

--- a/tests/api_tests/test_interfaces.py
+++ b/tests/api_tests/test_interfaces.py
@@ -162,12 +162,12 @@ def test_tree_traversal(site, client):
     assert_success(client.retrieve(uri), expected)
 
     # test root by calling it on ifc4
-    expected = [ifc1]
+    expected = ifc1
     uri = reverse('interface-root', args=(site.id, ifc4['id']))
     assert_success(client.retrieve(uri), expected)
 
     # test parent by calling it on ifc5
-    expected = [ifc2]
+    expected = ifc2
     uri = reverse('interface-parent', args=(site.id, ifc5['id']))
     assert_success(client.retrieve(uri), expected)
 

--- a/tests/model_tests/test_interfaces.py
+++ b/tests/model_tests/test_interfaces.py
@@ -32,6 +32,50 @@ def test_creation(device):
         iface.save()
 
 
+def test_tree_methods(device):
+    iface = models.Interface.objects.create(
+        device = device, name = 'eth0'
+    )
+    iface1 = models.Interface.objects.create(
+        device = device, name = 'eth0.0', parent = iface
+    )
+    iface2 = models.Interface.objects.create(
+        device = device, name = 'eth0.1', parent = iface
+    )
+    iface3 = models.Interface.objects.create(
+        device = device, name = 'eth0.2', parent = iface1
+    )
+    iface4 = models.Interface.objects.create(
+        device = device, name = 'eth0.3', parent = iface
+    )
+    assert iface1.parent.id is iface.id
+    assert iface3.get_root()[0].id is iface.id
+
+    children = [x.id for x in iface.get_children()]
+    expected = [iface1.id, iface2.id, iface4.id]
+    children.sort()
+    expected.sort()
+    assert children == expected
+
+    descendants = [x.id for x in iface.get_descendants()]
+    expected = [iface1.id, iface2.id, iface3.id, iface4.id]
+    expected.sort()
+    descendants.sort()
+    assert descendants == expected
+
+    ancestors = [x.id for x in iface3.get_ancestors()]
+    expected = [iface1.id, iface.id]
+    expected.sort()
+    ancestors.sort()
+    assert ancestors == expected
+
+    siblings = [x.id for x in iface4.get_siblings()]
+    expected = [iface1.id, iface2.id]
+    siblings.sort()
+    expected.sort()
+    assert siblings == expected
+    
+
 def test_speed(device):
     """Test interface speed."""
     iface = models.Interface.objects.create(device=device, name='eth0')

--- a/tests/model_tests/test_interfaces.py
+++ b/tests/model_tests/test_interfaces.py
@@ -49,7 +49,7 @@ def test_tree_methods(device):
         device = device, name = 'eth0.3', parent = iface
     )
     assert iface1.parent.id is iface.id
-    assert iface3.get_root()[0].id is iface.id
+    assert iface3.get_root().id is iface.id
 
     children = [x.id for x in iface.get_children()]
     expected = [iface1.id, iface2.id, iface4.id]
@@ -74,7 +74,7 @@ def test_tree_methods(device):
     siblings.sort()
     expected.sort()
     assert siblings == expected
-    
+
 
 def test_speed(device):
     """Test interface speed."""


### PR DESCRIPTION
Added following methods in ``InterfaceViewSet`` which can be invoked by get requests to return view sets

1. parent
2. ancestors
3. children
4. descendants
5. siblings
6. root

Also implemented following methods in ``Interface`` model class in ``models.py`` which get invoked in the view methods

1. get_ancestors
2. get_children
3. get_descendants
4. get_root
5. get_siblings

Also added tests in ``tests/api_tests/test_interfaces.py`` and ``tests/model_tests/test_interfaces.py``
