### PR TITLE
Fix create interface in web ui

### DIFF
--- a/nsot/static/src/js/controllers.js
+++ b/nsot/static/src/js/controllers.js
@@ -639,7 +639,7 @@
         });
 
         $("body").on("show.bs.modal", "#createInterfaceModal", function(e){
-            Device.query({siteId: siteId}, function(response){
+            Device.query({siteId: siteId, limit: 500}, function(response){
                 $scope.devices = response.data;
                 $scope.formData.devices = _.chain($scope.devices).value();
                 /*


### PR DESCRIPTION
This commit fixes bug in web ui when creating new interface. Without limit setting, the device query returns list instead of object. Because the query action does not have isArray:true, the response.data is returned as undefined.