### PR TITLE
Bugfixes to modifying users from the Django admin panel.

### DIFF
--- a/nsot/admin.py
+++ b/nsot/admin.py
@@ -13,7 +13,7 @@ from . import models
 class UserAdmin(EmailUserAdmin):
     fieldsets = (
         (None, {
-            'fields': ('email', 'secret_key'),
+            'fields': ('email', 'secret_key', 'password'),
         }),
         (_('Permissions'), {
             'fields': (

--- a/nsot/util/commands.py
+++ b/nsot/util/commands.py
@@ -15,6 +15,11 @@ __all__ = ('NsotCommand', 'CommandError')
 
 class NsotCommand(BaseCommand):
     """Base management command for NSoT that implements a custom logger."""
+
+    # This is here to alleviate an AttributeError when getting /admin/jsi18n/
+    # Ref: https://github.com/dropbox/nsot/issues/279
+    leave_locale_alone = True
+
     def create_parser(self, prog_name, subcommand):
         """Override default parser to include default values in help."""
         parser = super(NsotCommand, self).create_parser(


### PR DESCRIPTION
- Fix #279: Bugfix in fetching locale-aware javascript for admin panel by
  telling  `nsot.util.commands.NsotCommand` to leave locale settings
  alone.
- Fix #280: Fix 500 error when modifying users in admin panel by adding
  the password field back into the user change form for display
  purposes only.