### PR TITLE
New setting to toggle whether new auth_header users should be superuser

### DIFF
--- a/nsot/conf/settings.py
+++ b/nsot/conf/settings.py
@@ -157,7 +157,7 @@ REST_FRAMEWORK = {
     'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.AcceptHeaderVersioning',
     'DEFAULT_VERSION': NSOT_API_VERSION,
     'DEFAULT_PERMISSION_CLASSES': (
-        'rest_framework.permissions.IsAdminUser',
+        'rest_framework.permissions.DjangoModelPermissions',
     ),
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'nsot.api.auth.AuthTokenAuthentication',
@@ -281,6 +281,14 @@ CSRF_COOKIE_NAME = '_xsrf'
 # https://github.com/django/django/commit/668d53c
 # Default: 'X-CSRFToken'
 # CSRF_HEADER_NAME = 'X-XSRFToken'
+
+# Whether to create new users as superusers. If True, when new users are created
+# they will be given superuser permissions. If False, new users will not be
+# given superuser and it will be expected that permissions will be defined to
+# control admin privileges. This only applies to users automatically created
+# when authenticated using the "auth header" method, which is the default.
+# Default: True
+NSOT_NEW_USERS_AS_SUPERUSER = True
 
 ################
 # Static files #

--- a/nsot/middleware/auth.py
+++ b/nsot/middleware/auth.py
@@ -42,9 +42,11 @@ class EmailHeaderBackend(backends.RemoteUserBackend):
             return username
 
     def configure_user(self, user):
-        """Make all new users superusers and staff."""
-        user.is_superuser = True
-        user.is_staff = True
-        user.save()
+        """Check whether to make new users superusers."""
+        if settings.NSOT_NEW_USERS_AS_SUPERUSER:
+            user.is_superuser = True
+            user.is_staff = True
+            user.save()
+
         log.debug('Created new user: %s', user)
         return user

--- a/tests/api_tests/fixtures.py
+++ b/tests/api_tests/fixtures.py
@@ -3,7 +3,7 @@ import json
 import logging
 import os
 import pytest
-from pytest_django.fixtures import live_server, django_user_model
+from pytest_django.fixtures import live_server, django_user_model, settings
 import requests
 
 from .util import Client, TestSite
@@ -43,3 +43,10 @@ def client(live_server):
 def user_client(live_server):
     """Create and return a non-admin client."""
     return Client(live_server, user='user', api_version=API_VERSION)
+
+
+@pytest.fixture
+def nosuperuser_settings(settings):
+    """Return settings that have default superuser users disabled."""
+    settings.NSOT_NEW_USERS_AS_SUPERUSER = False
+    return settings


### PR DESCRIPTION
This adds a new setting called `NSOT_NEW_USERS_AS_SUPERUSER` which defaults to `True`, to toggle whether users coming in via the `auth_header` method (proxy authentication) are created with superuser permissions.

If toggled to `False`, new users are not given superuser and it will be expected that custom permissions will be utilized to control admin privileges.

This also updates the API permissions validation from requiring "staff" permissions to requiring model permissions. For existing users and default behaviors, there is no impact.

Since this has not changed any of the *default* behavior, no new unit tests have been introduced at this time. This change is laying the groundwork for a future release where we'll change the default permissions to be more granular and we'll implement legit testing of the permissions features at that time.