### PR TITLE
Change diffs and performance improvements

### DIFF
--- a/nsot/api/views.py
+++ b/nsot/api/views.py
@@ -195,6 +195,10 @@ class ChangeViewSet(BaseNsotViewSet):
     serializer_class = serializers.ChangeSerializer
     filter_fields = ('event', 'resource_name', 'resource_id')
 
+    @detail_route(methods=['get'])
+    def diff(self, request, *args, **kwargs):
+        return self.success(self.get_object().diff)
+
 
 class NsotViewSet(BaseNsotViewSet, viewsets.ModelViewSet):
     """

--- a/nsot/migrations/0032_add_indicies_to_change.py
+++ b/nsot/migrations/0032_add_indicies_to_change.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('nsot', '0031_populate_circuit_name_slug'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='change',
+            name='change_at',
+            field=models.DateTimeField(help_text='The timestamp of this Change.', auto_now_add=True, db_index=True),
+        ),
+        migrations.AlterIndexTogether(
+            name='change',
+            index_together=set([('resource_name', 'resource_id'), ('resource_name', 'event')]),
+        ),
+    ]

--- a/nsot/models.py
+++ b/nsot/models.py
@@ -5,11 +5,11 @@ from calendar import timegm
 from cryptography.fernet import (Fernet, InvalidToken)
 from custom_user.models import AbstractEmailUser
 import difflib
+from django.apps import apps
 from django.db import models
 from django.db.models.query_utils import Q
 from django.conf import settings
 from django.core.cache import cache as djcache
-from django.shortcuts import get_object_or_404
 from django.utils import timezone
 import ipaddress
 import json
@@ -2186,14 +2186,14 @@ class Change(models.Model):
                 resource_name=self.resource_name
             ).order_by(
                 '-change_at'
-            )[0]
+            ).first()
             old = json.dumps(old_change._resource, indent=2, sort_keys=True)
 
         if self.event == 'Delete':
             current = ''
         else:
-            resource = globals()[self.resource_name]
-            obj = get_object_or_404(resource, pk=self.resource_id)
+            resource = apps.get_model(self._meta.app_label, self.resource_name)
+            obj = resource.objects.get(pk=self.resource_id)
 
             serializer_class = self.get_serializer_for_resource(
                     self.resource_name)

--- a/nsot/models.py
+++ b/nsot/models.py
@@ -2068,7 +2068,7 @@ class Change(models.Model):
         help_text='The User that initiated this Change.'
     )
     change_at = models.DateTimeField(
-        auto_now_add=True, null=False,
+        auto_now_add=True, db_index=True, null=False,
         help_text='The timestamp of this Change.'
     )
     event = models.CharField(
@@ -2095,6 +2095,10 @@ class Change(models.Model):
 
     class Meta:
         get_latest_by = 'change_at'
+        index_together = (
+            ('resource_name', 'resource_id'),
+            ('resource_name', 'event'),
+        )
 
     def __unicode__(self):
         return u'%s %s(%s)' % (self.event, self.resource_name,

--- a/tests/model_tests/test_changes.py
+++ b/tests/model_tests/test_changes.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import pytest
+
+from django.db import IntegrityError
+from django.db.models import ProtectedError
+from django.core.exceptions import ValidationError as DjangoValidationError
+import ipaddress
+import json
+import logging
+import re
+
+from nsot import exc, models
+
+from .fixtures import device, user, site
+
+
+# Allow everything in there to access the DB
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def create(device, user):
+    models.Change.objects.create(event='Create', obj=device, user=user)
+
+
+def test_diff_device_hostname(create, device, user):
+    device.hostname = 'foo-bar3'
+    device.save()
+    update = models.Change.objects.create(event='Update', obj=device,
+                                          user=user)
+
+    assert '-   "hostname": "foo-bar1"' in update.diff
+    assert '+   "hostname": "foo-bar3"' in update.diff
+
+
+def test_diff_noop(create, device, user):
+    update = models.Change.objects.create(event='Update', obj=device,
+                                          user=user)
+
+    blob = json.dumps(update.resource, indent=2, sort_keys=True)
+
+    for line_a, line_b in zip(update.diff.splitlines(), blob.splitlines()):
+        assert line_a.strip() == line_b.strip()
+
+
+def test_diff_delete(create, device, user):
+    delete = models.Change.objects.create(event='Delete', obj=device,
+                                          user=user)
+    blob = json.dumps(delete.resource, indent=2, sort_keys=True)
+
+    for line_a, line_b in zip(delete.diff.splitlines(), blob.splitlines()):
+        assert line_a == '- ' + line_b


### PR DESCRIPTION
Some indicies were added to the Change object, notably on `change_at` as well as a couple of common lookups: `(resource_name, resource_id)` and `(resource_name, event)`. These greatly speeds up lookups, especially the `change_at` index which for example makes the CLI command `nsot changes list -l 5` no longer take seconds to return data.

Additionally I added a `diff` API endpoint to `/changes/`, which is a thin wrapper around a new `diff()` method on `Change`. What this does is take the JSON representations of the given resource at its current state and the state before the Change happened, and returns a unified diff of those two. 

Here's an example of what the API returns, taken from the updated CLI that supports this:
```
$ nsot changes list -i 2946025 diff
  {
    "attributes": {
      "facility": "nrt1", 
      "metro": "nrt", 
-     "monitor": "ignored"
?                 ^^^ ^

+     "monitor": "collected"
?                 ^ ^^^^^

    }, 
    "hostname": "jawn", 
    "id": 29936, 
    "site_id": 1
  }
```