### PR TITLE
Implement natural keys as primary keys for related fields

### DIFF
--- a/nsot/api/views.py
+++ b/nsot/api/views.py
@@ -47,7 +47,7 @@ class BaseNsotViewSet(viewsets.ReadOnlyModelViewSet):
         :param filter_value:
             Value to be used to filter by natural_key
         """
-        raise NotImplementedError('This must be defined in a subclass.')
+        return {self.natural_key: filter_value}
 
     def not_found(self, pk=None, site_pk=None, msg=None):
         """Standard formatting for 404 errors."""
@@ -397,10 +397,6 @@ class DeviceViewSet(ResourceViewSet):
 
         return self.serializer_class
 
-    def get_natural_key_kwargs(self, filter_value):
-        """Return a dict of kwargs for natural_key lookup."""
-        return {self.natural_key: filter_value}
-
     @detail_route(methods=['get'])
     def interfaces(self, request, pk=None, site_pk=None, *args, **kwargs):
         """Return all interfaces for this Device."""
@@ -641,13 +637,7 @@ class InterfaceViewSet(ResourceViewSet):
     # Match on device_hostname:name or pk id
     # Being pretty vague here, so as to be minimally prescriptive
     lookup_value_regex = '[^:]+:([^/]+|.+[0-9])|[0-9]+'
-    natural_key = ('device_hostname', 'name')
-
-    def get_natural_key_kwargs(self, filter_value):
-        """Return a dict of kwargs for natural_key lookup."""
-        # Breakout the device and interface
-        device, interface = filter_value.split(":", 1)
-        return dict(device_hostname=device, name=interface)
+    natural_key = 'name_slug'
 
     @cache_response(cache_errors=False, key_func=cache.list_key_func)
     def list(self, *args, **kwargs):
@@ -824,10 +814,6 @@ class CircuitViewSet(ResourceViewSet):
             return serializers.CircuitPartialUpdateSerializer
 
         return self.serializer_class
-
-    def get_natural_key_kwargs(self, filter_value):
-        """Return a dict of kwargs for natural_key lookup."""
-        return {self.natural_key: filter_value}
 
     @detail_route(methods=['get'])
     def addresses(self, request, pk=None, site_pk=None, *args, **kwargs):

--- a/nsot/migrations/0033_add_interface_name_slug.py
+++ b/nsot/migrations/0033_add_interface_name_slug.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('nsot', '0032_add_indicies_to_change'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='interface',
+            name='name_slug',
+            field=models.CharField(null=True, editable=False, max_length=255, help_text='Slugified version of the name field, used for the natural key', unique=True, db_index=True),
+        ),
+    ]

--- a/nsot/migrations/0034_populate_interface_name_slug.py
+++ b/nsot/migrations/0034_populate_interface_name_slug.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+from nsot.util import slugify
+
+
+def add_name_slug(apps, schema_editor):
+    """ Add a name_slug for every Interface that doesn't already have one """
+
+    Interface = apps.get_model('nsot', 'Interface')
+    for i in Interface.objects.filter(name_slug__isnull=True):
+        slug = '%s:%s' % (i.device_hostname, i.name)
+        i.name_slug = slugify(slug)
+        i.save()
+
+
+def remove_name_slug(apps, schema_editor):
+    Interface = apps.get_model('nsot', 'Interface')
+    Interface.objects.update(name_slug=None)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('nsot', '0033_add_interface_name_slug'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_name_slug, remove_name_slug)
+    ]

--- a/nsot/util/__init__.py
+++ b/nsot/util/__init__.py
@@ -1,7 +1,16 @@
+"""
+Utilities used across the project.
+"""
 
-__all__ = []
-
+# Core
 from . import core
 from .core import *  # noqa
 
+# Stats
+from . import stats
+from .stats import *  # noqa
+
+
+__all__ = []
 __all__.extend(core.__all__)
+__all__.extend(stats.__all__)

--- a/nsot/util/core.py
+++ b/nsot/util/core.py
@@ -21,7 +21,7 @@ _TRUTHY = set([
 __all__ = (
     'qpbool', 'normalize_auth_header', 'generate_secret_key', 'get_field_attr',
     'SetQuery', 'parse_set_query', 'generate_settings', 'initialize_app',
-    'main', 'cidr_to_dict', 'slugify'
+    'main', 'cidr_to_dict', 'slugify', 'slugify_interface'
 )
 
 
@@ -114,6 +114,35 @@ def slugify(s):
         s = s.replace(char, replacement)
 
     return s
+
+
+def slugify_interface(interface=None, device_hostname=None, name=None,
+                      **kwargs):
+    """
+    Return a slug (natural key) representation of an Interface.
+
+    If ``interface`` is not provided, ``device_hostname`` and ``name`` are
+    required. If all are provided, ``interface`` will take precedence.
+
+    :param interface:
+        Interface dict
+
+    :param device_hostname:
+        Device hostname
+
+    :param name:
+        Interface name
+
+    :rtype: str
+    """
+    if not (interface or (device_hostname and name)):
+        raise RuntimeError('Either interface or device_hostname/name required')
+
+    if interface is None:
+        interface = dict(device_hostname=device_hostname, name=name)
+
+    slug = '{device_hostname}:{name}'.format(**interface)
+    return slug
 
 
 #: Namedtuple for resultant items from ``parse_set_query()``
@@ -281,6 +310,8 @@ def initialize_app(config):
     :param config:
         Config object
     """
+    # FIXME(jathan): Move this to a setting/parameter that can be toggled when
+    # gevent workers are not used.
     USE_GEVENT = True  # Hard-coding gevent for now.
 
     if USE_GEVENT:

--- a/tests/api_tests/test_util.py
+++ b/tests/api_tests/test_util.py
@@ -6,8 +6,7 @@ from __future__ import unicode_literals, print_function
 
 import pytest
 
-from nsot.util import SetQuery, parse_set_query
-from nsot.util import slugify, stats
+from nsot import util
 
 
 def test_parse_set_query():
@@ -48,16 +47,16 @@ def test_parse_set_query():
 
     # Make sure that result matches expected_result
     for query, expected_result in set_tests.iteritems():
-        result = parse_set_query(query)
+        result = util.parse_set_query(query)
         assert result == expected_result
 
     # Test bogus stuff
     with pytest.raises(TypeError):
-        parse_set_query(None)
+        util.parse_set_query(None)
 
     # Test a bad string
     with pytest.raises(ValueError):
-        parse_set_query('foo="bar')  # Unbalanced quotes
+        util.parse_set_query('foo="bar')  # Unbalanced quotes
 
 
 PARENT = '10.47.216.0/22'
@@ -108,12 +107,13 @@ def test_stats_get_utilization(parent=PARENT, hosts=HOSTS):
     Make sure that getting network utilization stats is accurate.
     """
     expected = '10.47.216.0/22 - 14% used (139), 86% free (885)'
-    output = stats.calculate_network_utilization(parent, hosts, as_string=True)
+    output = util.calculate_network_utilization(parent, hosts, as_string=True)
 
     assert output == expected
 
 
 def test_slugify():
+    """Test ``util.slugify()``."""
     cases = [
         ('/', '_'),
         ('my cool string', 'my cool string'),
@@ -125,4 +125,26 @@ def test_slugify():
     ]
 
     for case, expected in cases:
-        assert slugify(case) == expected
+        assert util.slugify(case) == expected
+
+
+def test_slugify_interface():
+    """Test ``util.slugify_interface``."""
+
+    # Test interface dict input
+    interface = {'device_hostname': 'foo-bar1', 'name': 'ge-0/0/1'}
+    expected = 'foo-bar1:ge-0/0/1'
+    assert util.slugify_interface(interface) == expected
+
+    # Test kwarg input
+    assert util.slugify_interface(**interface) == expected
+
+    # Test bad inputs
+    with pytest.raises(RuntimeError):
+        util.slugify_interface()
+
+    with pytest.raises(RuntimeError):
+        util.slugify_interface(device_hostname='bogus')
+
+    with pytest.raises(RuntimeError):
+        util.slugify_interface(name='bogus')


### PR DESCRIPTION
Closes #262

API
- Natural keys can now be used any place a primary key could be used for
  related fields on Interfaces and Circuits.
- For Circuits, the default is now to display the A/Z endpoint interfaces by
  their natural key (e.g. `device_hostname:name` format).
- For Interfaces, the Device hostname may now be used to create or retrieve
  interfaces (no more need to lookup the Device ID first)
- Bugfix in `NsotSerializer` when `view` isn't part of the context that caused a
  crash.
- Interface now has a `name_slug` field that can be used for natural
  key lookups. This is now also officially the natural key field.
- Network now has a `cidr` field that can be used for displaying
  the `network_address/prefix_length` without additional effort
- Network now has a `parent` field that can be used for displaying
  the parent CIDR without an additional lookup
- All underlying serializer code has been streamlined to reduce code
  duplication where possible.
- All "update" serializers have been moved to subclasses of "partial
  update" serializers with extra required fields specified as "extra
  kwargs" vs. re-defining the fields.
- The fields for `site_id` and `attributes` have been moved to the base
  `ResourceSerializer` since ALL resources inherit these anyways.

Util
- Util stats functions can now be directly imported from `nsot.util`