### PR TITLE
Multiple bug fixes for Great Justice.

### DIFF
--- a/nsot/api/views.py
+++ b/nsot/api/views.py
@@ -6,7 +6,9 @@ import warnings
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.shortcuts import get_object_or_404
-from rest_framework import mixins, status as status_codes, viewsets
+from rest_framework import (
+    mixins, status as status_codes, permissions, viewsets
+)
 from rest_framework.views import APIView
 from rest_framework.decorators import detail_route, list_route
 from rest_framework.response import Response
@@ -900,6 +902,8 @@ class UserViewSet(BaseNsotViewSet, mixins.CreateModelMixin):
 
 class NotFoundViewSet(viewsets.GenericViewSet):
     """Catchall for bad API endpoints."""
+    permission_classes = (permissions.IsAuthenticated,)
+
     def get_queryset(self):
         return None
 

--- a/nsot/migrations/0034_populate_interface_name_slug.py
+++ b/nsot/migrations/0034_populate_interface_name_slug.py
@@ -3,18 +3,6 @@ from __future__ import unicode_literals
 
 from django.db import migrations, models
 
-from nsot.util import slugify
-
-
-def add_name_slug(apps, schema_editor):
-    """ Add a name_slug for every Interface that doesn't already have one """
-
-    Interface = apps.get_model('nsot', 'Interface')
-    for i in Interface.objects.filter(name_slug__isnull=True):
-        slug = '%s:%s' % (i.device_hostname, i.name)
-        i.name_slug = slugify(slug)
-        i.save()
-
 
 def remove_name_slug(apps, schema_editor):
     Interface = apps.get_model('nsot', 'Interface')
@@ -28,5 +16,13 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(add_name_slug, remove_name_slug)
+        # The "forwards" action was changed to a noop so that migration 0035
+        # fully replaces this one without having to do migration gymnastics.
+        # Users who previously upgraded to v1.2.0 and had migration 0034
+        # already applied will have to apply 0035, but new users will have 0034
+        # migration be a noop.
+        # In summary:
+        # - v1.2.0 =  0033 -> 0034 -> 0035
+        # - v1.2.1 =  0033 -> 0035
+        migrations.RunPython(migrations.RunPython.noop, remove_name_slug)
     ]

--- a/nsot/migrations/0035_fix_interface_name_slug.py
+++ b/nsot/migrations/0035_fix_interface_name_slug.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+from nsot.util import slugify_interface
+
+
+def add_name_slug(apps, schema_editor):
+    """Correctly name_slug for every Interface with slash in the name."""
+    Interface = apps.get_model('nsot', 'Interface')
+    for i in Interface.objects.iterator():
+        name_slug = slugify_interface(
+            device_hostname=i.device_hostname, name=i.name
+        )
+        i.name_slug = name_slug
+        i.save()
+
+
+def remove_name_slug(apps, schema_editor):
+    Interface = apps.get_model('nsot', 'Interface')
+    Interface.objects.update(name_slug=None)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('nsot', '0034_populate_interface_name_slug'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_name_slug, remove_name_slug)
+    ]

--- a/tests/api_tests/test_regressions.py
+++ b/tests/api_tests/test_regressions.py
@@ -343,3 +343,14 @@ def test_interface_assign_address_500_issues_168(client, site):
         client.put(ifc_detail_uri, data=json.dumps(ifc)),
         expected
     )
+
+
+def test_bogus_url_raises_404(client, site):
+    """Make sure that a bogus API URL always raises a 404."""
+    site_uri = site.detail_uri()
+    bogus_url = site_uri + 'pizza/'
+
+    assert_error(
+        client.get(bogus_url),
+        status.HTTP_404_NOT_FOUND
+    )


### PR DESCRIPTION
- Fixed a bug in the data migration for the newly-added
  `Interface.name_slug` field that would cause interfaces with `/` in
  their name to have their name slug incorrectly "slugified". A new data
  migration has been added to correct this.
- Fixed a bug that was occuring with model permissions enabled causing
  404 errors to be returned as 500 errors in specific cases. The 404
  handler has been changed to only check authenticated state and not
  model permisisons.
  - Added a new regression test to vlaidate this from here on out