### PR TITLE
Implemented Django-Guardian Auth Backend For Object Level Permissions

### DIFF
--- a/nsot/admin.py
+++ b/nsot/admin.py
@@ -1,15 +1,15 @@
 from __future__ import unicode_literals
 
-from custom_user.admin import EmailUserAdmin
 from django.contrib.auth import get_user_model
 from django.contrib import admin
 from django.utils.translation import ugettext_lazy as _
+from guardian.admin import GuardedModelAdmin
 
 from . import models
 
 
 # Register our custom User model
-class UserAdmin(EmailUserAdmin):
+class UserAdmin(GuardedModelAdmin):
     fieldsets = (
         (None, {
             'fields': ('email', 'secret_key', 'password'),
@@ -29,7 +29,7 @@ class UserAdmin(EmailUserAdmin):
 admin.site.register(get_user_model(), UserAdmin)
 
 
-class SiteAdmin(admin.ModelAdmin):
+class SiteAdmin(GuardedModelAdmin):
     list_display = ('name', 'description')
     list_filter = ('name',)
 
@@ -37,7 +37,7 @@ class SiteAdmin(admin.ModelAdmin):
 admin.site.register(models.Site, SiteAdmin)
 
 
-class AttributeAdmin(admin.ModelAdmin):
+class AttributeAdmin(GuardedModelAdmin):
     list_display = ('name', 'resource_name', 'description', 'required',
                     'display', 'multi', 'site')
     list_filter = ('name', 'resource_name', 'required', 'multi', 'site')
@@ -46,7 +46,7 @@ class AttributeAdmin(admin.ModelAdmin):
 admin.site.register(models.Attribute, AttributeAdmin)
 
 
-class ValueAdmin(admin.ModelAdmin):
+class ValueAdmin(GuardedModelAdmin):
     list_display = ('name', 'value', 'resource_name', 'resource_id')
     list_filter = ('name', 'value', 'resource_name')
 
@@ -54,7 +54,7 @@ class ValueAdmin(admin.ModelAdmin):
 admin.site.register(models.Value, ValueAdmin)
 
 
-class ChangeAdmin(admin.ModelAdmin):
+class ChangeAdmin(GuardedModelAdmin):
     list_display = ('id', 'user', 'event', 'resource_name', 'resource_id',
                     'get_change_at', 'resource_name', 'site')
     list_filter = ('event', 'site')
@@ -63,7 +63,7 @@ class ChangeAdmin(admin.ModelAdmin):
 admin.site.register(models.Change, ChangeAdmin)
 
 
-class DeviceAdmin(admin.ModelAdmin):
+class DeviceAdmin(GuardedModelAdmin):
     list_display = ('hostname', 'site')
     list_filter = ('site',)
 
@@ -73,7 +73,7 @@ class DeviceAdmin(admin.ModelAdmin):
 admin.site.register(models.Device, DeviceAdmin)
 
 
-class NetworkAdmin(admin.ModelAdmin):
+class NetworkAdmin(GuardedModelAdmin):
     mptt_level_indent = 10
     mptt_indent_field = 'cidr'
     list_display = ('cidr', 'network_address', 'prefix_length', 'ip_version',
@@ -90,7 +90,7 @@ class NetworkAdmin(admin.ModelAdmin):
 admin.site.register(models.Network, NetworkAdmin)
 
 
-class InterfaceAdmin(admin.ModelAdmin):
+class InterfaceAdmin(GuardedModelAdmin):
     list_display = ('name', 'device', 'parent', 'mac_address', 'type', 'speed')
     list_filter = ('type', 'speed')
 

--- a/nsot/admin.py
+++ b/nsot/admin.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+from custom_user.admin import EmailUserAdmin
 from django.contrib.auth import get_user_model
 from django.contrib import admin
 from django.utils.translation import ugettext_lazy as _
@@ -9,7 +10,7 @@ from . import models
 
 
 # Register our custom User model
-class UserAdmin(GuardedModelAdmin):
+class UserAdmin(EmailUserAdmin):
     fieldsets = (
         (None, {
             'fields': ('email', 'secret_key', 'password'),
@@ -54,7 +55,7 @@ class ValueAdmin(GuardedModelAdmin):
 admin.site.register(models.Value, ValueAdmin)
 
 
-class ChangeAdmin(GuardedModelAdmin):
+class ChangeAdmin(admin.ModelAdmin):
     list_display = ('id', 'user', 'event', 'resource_name', 'resource_id',
                     'get_change_at', 'resource_name', 'site')
     list_filter = ('event', 'site')

--- a/nsot/conf/settings.py
+++ b/nsot/conf/settings.py
@@ -36,6 +36,7 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
     'django_extensions',
     'django_filters',
+    'guardian',
     'smart_selects',
     'rest_framework',
     'rest_framework_swagger',
@@ -52,6 +53,7 @@ AUTH_USER_MODEL = 'nsot.User'
 AUTHENTICATION_BACKENDS = (
     'nsot.middleware.auth.EmailHeaderBackend',
     'django.contrib.auth.backends.ModelBackend',
+    'guardian.backends.ObjectPermissionBackend',
 )
 
 # A tuple of middleware classes to use.

--- a/nsot/conf/settings.py
+++ b/nsot/conf/settings.py
@@ -297,7 +297,15 @@ NSOT_NEW_USERS_AS_SUPERUSER = True
 # Guardian #
 ############
 
+# This setting is to silence any warnings raised by Guardian due to the usage
+# of a custom auth backend implementation as opposed to
+# guardian.backends.ObjectPermissionBackend
 SILENCED_SYSTEM_CHECKS = ['guardian.W001']
+
+# The Guardian anonymous user is different to the Django Anonymous user. 
+# The Django Anonymous user does not have an entry in the database,
+# however the Guardian anonymous user does. 
+ANONYMOUS_USER_NAME = 'anonymous@service.local'
 
 ################
 # Static files #

--- a/nsot/conf/settings.py
+++ b/nsot/conf/settings.py
@@ -46,6 +46,7 @@ INSTALLED_APPS = (
 
 # The model to use to represent a User.
 AUTH_USER_MODEL = 'nsot.User'
+ANONYMOUS_USER_NAME = 'anonymous@service.local'
 
 # A tuple of authentication backend classes (as strings) to use when attempting
 # to authenticate a user.
@@ -53,7 +54,7 @@ AUTH_USER_MODEL = 'nsot.User'
 AUTHENTICATION_BACKENDS = (
     'nsot.middleware.auth.EmailHeaderBackend',
     'django.contrib.auth.backends.ModelBackend',
-    'guardian.backends.ObjectPermissionBackend',
+    'nsot.middleware.auth.NsotObjectPermissionsBackend',
 )
 
 # A tuple of middleware classes to use.
@@ -291,6 +292,12 @@ CSRF_COOKIE_NAME = '_xsrf'
 # when authenticated using the "auth header" method, which is the default.
 # Default: True
 NSOT_NEW_USERS_AS_SUPERUSER = True
+
+############
+# Guardian #
+############
+
+SILENCED_SYSTEM_CHECKS = ['guardian.W001']
 
 ################
 # Static files #

--- a/nsot/middleware/auth.py
+++ b/nsot/middleware/auth.py
@@ -8,6 +8,7 @@ from django.core.exceptions import ValidationError
 from django.core.validators import EmailValidator
 from django.utils.log import getLogger
 from guardian.backends import ObjectPermissionBackend
+from guardian.core import ObjectPermissionChecker
 
 from ..util import normalize_auth_header
 
@@ -57,7 +58,7 @@ class NsotObjectPermissionsBackend(ObjectPermissionBackend):
     """Custom backend that overloads django-guardian's has_perm method."""
     def has_perm(self, user_obj, perm, obj=None):
         """
-        Returns ``True`` if ``grp_obj`` has ``perm`` for ``obj``. If no
+        Returns ``True`` if ``user_obj`` has ``perm`` for ``obj``. If no
         ``obj`` is provided, ``False`` is returned.
 
         However, if ``grp_obj`` does not have ``perm`` for ``obj``,
@@ -71,11 +72,11 @@ class NsotObjectPermissionsBackend(ObjectPermissionBackend):
         if check:
             return True
 
-        if hasattr(obj, 'get_ancestors', False):
+        if hasattr(obj, 'get_ancestors'):
             ancestors = obj.get_ancestors()
+            ancestor_perm_check = ObjectPermissionChecker(user_obj)
 
-            return any(check.has_perm(perm, a) for a in ancestors)
+            return any(ancestor_perm_check.has_perm(perm, a)
+                       for a in ancestors)
 
-        # (TODO nseshan): Need to modify the logic for obj without ancestors
-        else:
-            return False
+        return False

--- a/nsot/middleware/auth.py
+++ b/nsot/middleware/auth.py
@@ -65,7 +65,7 @@ class NsotObjectPermissionsBackend(ObjectPermissionBackend):
         the ancestor tree has ``perm`` for the ``obj``, then ``True`` is
         returned, else ``False`` is returned.
         """
-        check = super(NsotObjectPermissionsBackend,self).has_perm(
+        check = super(NsotObjectPermissionsBackend, self).has_perm(
             user_obj, perm, obj
         )
         if check:

--- a/nsot/middleware/auth.py
+++ b/nsot/middleware/auth.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import EmailValidator
 from django.utils.log import getLogger
+from guardian.backends import ObjectPermissionBackend
 
 from ..util import normalize_auth_header
 
@@ -50,3 +51,31 @@ class EmailHeaderBackend(backends.RemoteUserBackend):
 
         log.debug('Created new user: %s', user)
         return user
+
+
+class NsotObjectPermissionsBackend(ObjectPermissionBackend):
+    """Custom backend that overloads django-guardian's has_perm method."""
+    def has_perm(self, user_obj, perm, obj=None):
+        """
+        Returns ``True`` if ``grp_obj`` has ``perm`` for ``obj``. If no
+        ``obj`` is provided, ``False`` is returned.
+
+        However, if ``grp_obj`` does not have ``perm`` for ``obj``,
+        the ancestor tree for ``obj`` is checked against. If any node in
+        the ancestor tree has ``perm`` for the ``obj``, then ``True`` is
+        returned, else ``False`` is returned.
+        """
+        check = super(NsotObjectPermissionsBackend,self).has_perm(
+            user_obj, perm, obj
+        )
+        if check:
+            return True
+
+        if hasattr(obj, 'get_ancestors', False):
+            ancestors = obj.get_ancestors()
+
+            return any(check.has_perm(perm, a) for a in ancestors)
+
+        # (TODO nseshan): Need to modify the logic for obj without ancestors
+        else:
+            return False

--- a/nsot/models.py
+++ b/nsot/models.py
@@ -2242,6 +2242,7 @@ def update_device_interfaces(sender, instance, **kwargs):
     interfaces = Interface.objects.filter(device=instance)
     interfaces.update(device_hostname=instance.hostname)
 
+
 # Register signals
 resource_subclasses = Resource.__subclasses__()
 for model_class in resource_subclasses:

--- a/nsot/models.py
+++ b/nsot/models.py
@@ -2242,7 +2242,6 @@ def update_device_interfaces(sender, instance, **kwargs):
     interfaces = Interface.objects.filter(device=instance)
     interfaces.update(device_hostname=instance.hostname)
 
-
 # Register signals
 resource_subclasses = Resource.__subclasses__()
 for model_class in resource_subclasses:
@@ -2252,7 +2251,6 @@ for model_class in resource_subclasses:
         sender=model_class,
         dispatch_uid='value_post_delete_' + model_class.__name__
     )
-
 
 # Invalidate Interface cache on save/delete
 models.signals.post_save.connect(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 -r requirements.txt
 argh~=0.26.1
 betamax~=0.4.2
-django-guardian~=1.4.9
 docutils~=0.12.0
 ipdb~=0.9.3
 flake8~=3.3.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 -r requirements.txt
 argh~=0.26.1
 betamax~=0.4.2
+django-guardian~=1.4.9
 docutils~=0.12.0
 ipdb~=0.9.3
 flake8~=3.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ Django~=1.8.11
 django-custom-user~=0.5.0
 django-extensions~=1.5.7
 django-filter~=0.15.3
+django-guardian~=1.4.9
 django-jinja~=1.4.1
 django-macaddress~=1.3.2
 django-rest-swagger~=0.3.5

--- a/tests/model_tests/fixtures.py
+++ b/tests/model_tests/fixtures.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.models import Group
 import pytest
 from pytest_django.fixtures import  django_user_model, transactional_db
 import logging
@@ -64,3 +65,10 @@ def circuit(site):
         endpoint_a=iface_a, endpoint_z=iface_z
     )
     return circuit
+
+
+@pytest.fixture
+def test_group():
+    """Create and return a Group object."""
+    test_group = Group.objects.create(name='test_group')
+    return test_group

--- a/tests/model_tests/test_middleware_auth.py
+++ b/tests/model_tests/test_middleware_auth.py
@@ -12,9 +12,11 @@ import logging
 from nsot import exc, models
 from nsot.middleware.auth import NsotObjectPermissionsBackend
 
-from .fixtures import admin_user, user, site, transactional_db
+from .fixtures import test_group, user, site
 
-def test_object_level_permissions_with_ancestors(site, user):
+def test_object_level_permissions_with_ancestors(site, user, test_group):
+    """Test to check object level permissions for objects with a
+    ``get_ancestors`` method implementation"""
     net_8  = models.Network.objects.create(site=site, cidr=u'8.0.0.0/8')
     net_24 = models.Network.objects.create(site=site, cidr=u'8.0.0.0/24')
     net_16 = models.Network.objects.create(site=site, cidr=u'8.0.0.0/16')
@@ -25,8 +27,7 @@ def test_object_level_permissions_with_ancestors(site, user):
     net_24.refresh_from_db()
     net_16.refresh_from_db()
 
-    grp = Group.objects.create(name='test_group')
-    user.groups.add(grp)
+    user.groups.add(test_group)
 
     check_perms = NsotObjectPermissionsBackend()
     assert check_perms.has_perm(user, 'delete_network', net_24) is False

--- a/tests/model_tests/test_middleware_auth.py
+++ b/tests/model_tests/test_middleware_auth.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.contrib.auth.models import Group
+from guardian.shortcuts import assign_perm
+import pytest
+# Allow everything in there to access the DB
+pytestmark = pytest.mark.django_db
+
+import logging
+
+from nsot import exc, models
+from nsot.middleware.auth import NsotObjectPermissionsBackend
+
+from .fixtures import admin_user, user, site, transactional_db
+
+def test_object_level_permissions_with_ancestors(site, user):
+    net_8  = models.Network.objects.create(site=site, cidr=u'8.0.0.0/8')
+    net_24 = models.Network.objects.create(site=site, cidr=u'8.0.0.0/24')
+    net_16 = models.Network.objects.create(site=site, cidr=u'8.0.0.0/16')
+
+    # Need to refresh the objects from the db so the updated parent_ids are
+    # reflected.
+    net_8.refresh_from_db()
+    net_24.refresh_from_db()
+    net_16.refresh_from_db()
+
+    grp = Group.objects.create(name='test_group')
+    user.groups.add(grp)
+
+    check_perms = NsotObjectPermissionsBackend()
+    assert check_perms.has_perm(user, 'delete_network', net_24) is False
+
+    assign_perm('delete_network', user, net_8)
+    assert check_perms.has_perm(user, 'delete_network', net_8) is True
+    assert check_perms.has_perm(user, 'delete_network', net_24) is True


### PR DESCRIPTION
Implemented django-guardian to check for object level permissions for object models that have a `get_ancestors` method. 