### PR TITLE
Add a Protocol model

### DIFF
--- a/nsot/conf/settings.py
+++ b/nsot/conf/settings.py
@@ -454,16 +454,3 @@ IP_VERSIONS = ('4', '6')
 # - Compressed: 2620:100:6000::/40
 # Default: True
 NSOT_COMPRESS_IPV6 = True
-
-
-#############
-# Protocols #
-#############
-
-# Mapping of database representation of Protocol types to their verbose name,
-# which is used by the `type` field on the `Protocol` model.
-PROTOCOL_TYPE_CHOICES = (
-    ('bgp', 'BGP'),
-    ('isis', 'IS-IS'),
-    ('ospf', 'OSPF'),
-)

--- a/nsot/conf/settings.py
+++ b/nsot/conf/settings.py
@@ -302,9 +302,9 @@ NSOT_NEW_USERS_AS_SUPERUSER = True
 # guardian.backends.ObjectPermissionBackend
 SILENCED_SYSTEM_CHECKS = ['guardian.W001']
 
-# The Guardian anonymous user is different to the Django Anonymous user. 
+# The Guardian anonymous user is different to the Django Anonymous user.
 # The Django Anonymous user does not have an entry in the database,
-# however the Guardian anonymous user does. 
+# however the Guardian anonymous user does.
 ANONYMOUS_USER_NAME = 'anonymous@service.local'
 
 ################
@@ -450,7 +450,20 @@ HOST_PREFIXES = (32, 128)
 IP_VERSIONS = ('4', '6')
 
 # Whether to compress IPv6 for display purposes, for example:
-# - Exploded (default): 2620:0100:6000:0000:0000:0000:0000:0000/40 
+# - Exploded (default): 2620:0100:6000:0000:0000:0000:0000:0000/40
 # - Compressed: 2620:100:6000::/40
 # Default: True
 NSOT_COMPRESS_IPV6 = True
+
+
+#############
+# Protocols #
+#############
+
+# Mapping of database representation of Protocol types to their verbose name,
+# which is used by the `type` field on the `Protocol` model.
+PROTOCOL_TYPE_CHOICES = (
+    ('bgp', 'BGP'),
+    ('isis', 'IS-IS'),
+    ('ospf', 'OSPF'),
+)

--- a/nsot/migrations/0036_add_protocol.py
+++ b/nsot/migrations/0036_add_protocol.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+import django_extensions.db.fields.json
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('nsot', '0035_fix_interface_name_slug'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Protocol',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('_attributes_cache', django_extensions.db.fields.json.JSONField(help_text='Local cache of attributes. (Internal use only)', blank=True)),
+                ('type', models.CharField(db_index=True, max_length=8, choices=[(b'bgp', b'BGP'), (b'isis', b'IS-IS'), (b'ospf', b'OSPF')])),
+                ('asn', models.PositiveIntegerField(db_index=True)),
+                ('auth_string', models.CharField(default='', max_length=255)),
+                ('description', models.CharField(default='', max_length=255)),
+                ('circuit', models.ForeignKey(related_name='protocols', verbose_name='Circuit that this protocol is running over', to='nsot.Circuit')),
+                ('device', models.ForeignKey(related_name='protocols', verbose_name='Device that this protocol is running on', to='nsot.Device')),
+                ('site', models.ForeignKey(related_name='protocols', on_delete=django.db.models.deletion.PROTECT, to='nsot.Site', help_text='Unique ID of the Site this Protocol is under.')),
+            ],
+            options={
+                'ordering': ('device', 'asn'),
+            },
+        ),
+    ]

--- a/nsot/migrations/0036_add_protocol.py
+++ b/nsot/migrations/0036_add_protocol.py
@@ -60,7 +60,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='protocoltype',
             name='required_attributes',
-            field=models.ManyToManyField(related_name='protocol_types', to='nsot.Attribute', db_index=True),
+            field=models.ManyToManyField(help_text='All Attributes which are required by this ProtocolType. If a Protocol of this type is saved and is missing one of these attributes, a ValidationError will be raised.', related_name='protocol_types', to='nsot.Attribute', db_index=True),
         ),
         migrations.AddField(
             model_name='protocol',

--- a/nsot/migrations/0036_add_protocol.py
+++ b/nsot/migrations/0036_add_protocol.py
@@ -23,7 +23,7 @@ class Migration(migrations.Migration):
                 ('circuit', models.ForeignKey(related_name='protocols', blank=True, to='nsot.Circuit', help_text='Circuit that this protocol is running over.', null=True)),
                 ('device', models.ForeignKey(related_name='protocols', to='nsot.Device', help_text='Device that this protocol is running on')),
                 ('interface', models.ForeignKey(related_name='protocols', blank=True, to='nsot.Interface', help_text='Interface this protocol is running on. Either interface or circuit must be populated.', null=True)),
-                ('site', models.ForeignKey(related_name='protocols', on_delete=django.db.models.deletion.PROTECT, to='nsot.Site', help_text='Unique ID of the Site this Protocol is under.')),
+                ('site', models.ForeignKey(related_name='protocols', on_delete=django.db.models.deletion.PROTECT, blank=True, to='nsot.Site', help_text="Unique ID of the Site this Protocol is under. If not set, this be inherited off of the device's site", null=True, verbose_name='Site')),
             ],
             options={
                 'ordering': ('device',),
@@ -33,8 +33,8 @@ class Migration(migrations.Migration):
             name='ProtocolType',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('name', models.CharField(help_text='Name of this type of protocol (e.g. OSPF, BGP, etc.)', max_length=16, db_index=True)),
-                ('description', models.CharField(default='', max_length=255, blank=True)),
+                ('name', models.CharField(help_text='Name of this type of protocol (e.g. OSPF, BGP, etc.)', unique=True, max_length=16, db_index=True)),
+                ('description', models.CharField(default='', help_text='A description for this ProtocolType', max_length=255, blank=True)),
             ],
         ),
         migrations.AlterField(
@@ -65,6 +65,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='protocol',
             name='type',
-            field=models.ForeignKey(related_name='protocols', to='nsot.ProtocolType'),
+            field=models.ForeignKey(related_name='protocols', to='nsot.ProtocolType', help_text='The type of this Protocol'),
         ),
     ]

--- a/nsot/migrations/0036_add_protocol.py
+++ b/nsot/migrations/0036_add_protocol.py
@@ -18,16 +18,53 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('_attributes_cache', django_extensions.db.fields.json.JSONField(help_text='Local cache of attributes. (Internal use only)', blank=True)),
-                ('type', models.CharField(db_index=True, max_length=8, choices=[(b'bgp', b'BGP'), (b'isis', b'IS-IS'), (b'ospf', b'OSPF')])),
-                ('asn', models.PositiveIntegerField(db_index=True)),
-                ('auth_string', models.CharField(default='', max_length=255)),
-                ('description', models.CharField(default='', max_length=255)),
-                ('circuit', models.ForeignKey(related_name='protocols', verbose_name='Circuit that this protocol is running over', to='nsot.Circuit')),
-                ('device', models.ForeignKey(related_name='protocols', verbose_name='Device that this protocol is running on', to='nsot.Device')),
+                ('auth_string', models.CharField(default='', help_text='Authentication string (such as MD5 sum)', max_length=255, blank=True)),
+                ('description', models.CharField(default='', help_text='Description for this Protocol', max_length=255, blank=True)),
+                ('circuit', models.ForeignKey(related_name='protocols', blank=True, to='nsot.Circuit', help_text='Circuit that this protocol is running over.', null=True)),
+                ('device', models.ForeignKey(related_name='protocols', to='nsot.Device', help_text='Device that this protocol is running on')),
+                ('interface', models.ForeignKey(related_name='protocols', blank=True, to='nsot.Interface', help_text='Interface this protocol is running on. Either interface or circuit must be populated.', null=True)),
                 ('site', models.ForeignKey(related_name='protocols', on_delete=django.db.models.deletion.PROTECT, to='nsot.Site', help_text='Unique ID of the Site this Protocol is under.')),
             ],
             options={
-                'ordering': ('device', 'asn'),
+                'ordering': ('device',),
             },
+        ),
+        migrations.CreateModel(
+            name='ProtocolType',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(help_text='Name of this type of protocol (e.g. OSPF, BGP, etc.)', max_length=16, db_index=True)),
+                ('description', models.CharField(default='', max_length=255, blank=True)),
+            ],
+        ),
+        migrations.AlterField(
+            model_name='attribute',
+            name='resource_name',
+            field=models.CharField(help_text='The name of the Resource to which this Attribute is bound.', max_length=20, verbose_name='Resource Name', db_index=True, choices=[('Device', 'Device'), ('Interface', 'Interface'), ('Protocol', 'Protocol'), ('Network', 'Network'), ('Circuit', 'Circuit')]),
+        ),
+        migrations.AlterField(
+            model_name='change',
+            name='resource_name',
+            field=models.CharField(help_text='The name of the Resource for this Change.', max_length=20, verbose_name='Resource Type', db_index=True, choices=[('Protocol', 'Protocol'), ('Network', 'Network'), ('Attribute', 'Attribute'), ('Site', 'Site'), ('Interface', 'Interface'), ('Circuit', 'Circuit'), ('Device', 'Device')]),
+        ),
+        migrations.AlterField(
+            model_name='network',
+            name='is_ip',
+            field=models.BooleanField(default=False, help_text='Whether the Network is a host address or not.', db_index=True, editable=False),
+        ),
+        migrations.AlterField(
+            model_name='value',
+            name='resource_name',
+            field=models.CharField(help_text='The name of the Resource type to which the Value is bound.', max_length=20, verbose_name='Resource Type', db_index=True, choices=[('Protocol', 'Protocol'), ('Network', 'Network'), ('Attribute', 'Attribute'), ('Site', 'Site'), ('Interface', 'Interface'), ('Circuit', 'Circuit'), ('Device', 'Device')]),
+        ),
+        migrations.AddField(
+            model_name='protocoltype',
+            name='required_attributes',
+            field=models.ManyToManyField(related_name='protocol_types', to='nsot.Attribute', db_index=True),
+        ),
+        migrations.AddField(
+            model_name='protocol',
+            name='type',
+            field=models.ForeignKey(related_name='protocols', to='nsot.ProtocolType'),
         ),
     ]

--- a/nsot/models.py
+++ b/nsot/models.py
@@ -1728,7 +1728,12 @@ class ProtocolType(models.Model):
         max_length=255, default='', blank=True, null=False
     )
     required_attributes = models.ManyToManyField(
-        'Attribute', db_index=True, related_name='protocol_types'
+        'Attribute', db_index=True, related_name='protocol_types',
+        help_text=(
+            'All Attributes which are required by this ProtocolType. If a'
+            ' Protocol of this type is saved and is missing one of these'
+            ' attributes, a ValidationError will be raised.'
+        )
     )
 
     def __unicode__(self):
@@ -1803,7 +1808,8 @@ class Protocol(Resource):
 
     def local_interface(self):
         """
-        Returns the local interface attached to the circuit
+        Returns the local interface for this Protocol, either the set interface
+        or the local interface of circuit
         """
         if self.interface:
             return self.interface

--- a/nsot/models.py
+++ b/nsot/models.py
@@ -1726,24 +1726,26 @@ class Protocol(Resource):
 
     device = models.ForeignKey(
         Device, db_index=True, null=False, related_name='protocols',
-        verbose_name='Device that this protocol is running on'
+        help_text='Device that this protocol is running on',
     )
     circuit = models.ForeignKey(
         Circuit, db_index=True, null=False, related_name='protocols',
-        verbose_name='Circuit that this protocol is running over',
+        help_text='Circuit that this protocol is running over',
     )
     site = models.ForeignKey(
         Site, db_index=True, related_name='protocols',
         on_delete=models.PROTECT,
-        help_text='Unique ID of the Site this Protocol is under.'
+        help_text='Unique ID of the Site this Protocol is under.',
     )
 
     type = models.CharField(
-        max_length=8, choices=settings.PROTOCOL_TYPE_CHOICES, db_index=True
+        max_length=8, choices=settings.PROTOCOL_TYPE_CHOICES, db_index=True,
+        help_text='Type of the Protocol, e.g. OSPF, IS-IS, BGP',
     )
-    asn = models.PositiveIntegerField(db_index=True)
-    auth_string = models.CharField(max_length=255, default='')
-    description = models.CharField(max_length=255, default='')
+    auth_string = models.CharField(
+        max_length=255, default='',
+        help_text='Authentication string (such as MD5 sum)',
+    )
 
     def __unicode__(self):
         return u'%s over %s' % (self.get_type_display(), self.circuit)

--- a/tests/model_tests/test_protocols.py
+++ b/tests/model_tests/test_protocols.py
@@ -10,12 +10,56 @@ from .fixtures import circuit, site
 pytestmark = pytest.mark.django_db
 
 
+@pytest.fixture
+def asn_attribute(site):
+    return models.Attribute.objects.create(
+        site=site,
+        name='asn',
+        resource_name='Protocol',
+    )
+
+
+@pytest.fixture
+def bgp(asn_attribute):
+    bgp = models.ProtocolType.objects.create(
+        name='bgp',
+        description='Border Gateway Protocol',
+    )
+    bgp.required_attributes.add(asn_attribute)
+
+    return bgp
+
+
+@pytest.fixture
+def area_attribute(site):
+    return models.Attribute.objects.create(
+        site=site,
+        name='area',
+        resource_name='Protocol',
+    )
+
+
+@pytest.fixture
+def ospf(area_attribute):
+    ospf = models.ProtocolType.objects.create(
+        name='ospf',
+        description='Open Shortest Path First protocol',
+    )
+    ospf.required_attributes.add(area_attribute)
+
+    return ospf
+
+
 class TestCreation(object):
     @pytest.fixture
     def device(self, circuit):
         return circuit.endpoint_a.device
 
-    def test_normal_conditions(self, device, circuit):
+    @pytest.fixture
+    def interface(self, circuit):
+        return circuit.endpoint_a
+
+    def test_normal_conditions(self, device, circuit, bgp):
         """
         Under normal conditions, ensure that a Protocol can be created without
         raising any exceptions
@@ -23,16 +67,19 @@ class TestCreation(object):
         protocol = models.Protocol.objects.create(
             device=device,
             circuit=circuit,
-            type='bgp',
-            asn=1234,
-            description='My fancy peer'
+            type=bgp,
+            description='My fancy peer',
+            attributes={
+                'asn': '1234',
+            }
         )
+        protocol.save()
 
         assert protocol.site_id == device.site_id
         assert protocol in device.protocols.all()
         assert protocol in circuit.protocols.all()
 
-    def test_bad_circuit(self, device, circuit):
+    def test_bad_circuit(self, device, circuit, bgp):
         """
         Ensure a ValidationError is thrown when we try to create a Protocol
         where the Circuit is not attached to the Device
@@ -44,56 +91,112 @@ class TestCreation(object):
             models.Protocol.objects.create(
                 device=device,
                 circuit=bad_circuit,
-                type='bgp',
-                asn=1234
+                type=bgp,
+                attributes={
+                    'asn': '1234',
+                }
             )
 
-    def test_bad_type(self, device, circuit):
-        with pytest.raises(exc.ValidationError):
-            models.Protocol.objects.create(
-                device=device,
-                circuit=circuit,
-                type='oh no',
-                asn=1234
-            )
-
-    def test_attributes(self, device, circuit):
-        """ Ensure that we can set attributes on a Protocol """
+    def test_attributes(self, device, circuit, bgp):
+        """ Ensure that we can set arbitrary attributes on a Protocol """
         models.Attribute.objects.create(
             site=device.site, resource_name='Protocol', name='import_policies')
 
         protocol = models.Protocol.objects.create(
             device=device,
             circuit=circuit,
-            type='bgp',
-            asn=1234,
+            type=bgp,
             attributes={
+                'asn': '1234',
                 'import_policies': 'foo'
             }
         )
 
         assert protocol.get_attributes()['import_policies'] == 'foo'
 
+    def test_missing_attributes(self, device, circuit, bgp):
+        """
+        Test that a ValidationError is thrown when we try to create a Protocol.
+        The BGP ProtocolType we defined has a required attribute `asn`
+        """
+        with pytest.raises(exc.ValidationError):
+            models.Protocol.objects.create(
+                device=device,
+                circuit=circuit,
+                type=bgp,
+                attributes={},
+            )
+
+    def test_another_protocol(self, device, interface, ospf):
+        """
+        Test that we can add a Protocol with second ProtocolType and that it
+        doesn't raise any sort of exception
+        """
+        models.Protocol.objects.create(
+            device=device,
+            interface=interface,
+            type=ospf,
+            attributes={'area': 'threeve'}
+        )
+
+    def test_mixed_attrs(self, device, circuit, bgp, area_attribute):
+        """
+        Test that we can add a Protocol of one ProtocolType with an attribute
+        that's required by another ProtocolType without anything weird
+        happening
+        """
+        protocol = models.Protocol.objects.create(
+            device=device,
+            circuit=circuit,
+            type=bgp,
+            attributes={
+                'asn': '1234',
+                'area': 'threeve',
+            }
+        )
+
+        assert protocol.get_attributes()['asn'] == '1234'
+        assert protocol.get_attributes()['area'] == 'threeve'
+
 
 class TestInterfaces(object):
     @pytest.fixture
-    def protocol(self, circuit):
+    def protocol(self, circuit, bgp):
         device = circuit.endpoint_a.device
 
         return models.Protocol.objects.create(
             device=device,
             circuit=circuit,
-            type='bgp',
-            asn=1234
+            type=bgp,
+            attributes={
+                'asn': '1234',
+            }
         )
 
-    def test_local_interface(self, circuit, protocol):
+    @pytest.fixture
+    def interface(self, circuit):
+        return circuit.endpoint_a
+
+    @pytest.fixture
+    def interface_protocol(self, interface, ospf):
+        device = interface.device
+
+        return models.Protocol.objects.create(
+            device=device,
+            interface=interface,
+            type=ospf,
+            attributes={'area': '1234'},
+        )
+
+    def test_local_interface(self, circuit, protocol, interface,
+                             interface_protocol):
         assert protocol.local_interface() == circuit.endpoint_a
+        assert interface_protocol.local_interface() == interface
 
     def test_remote_interface(self, circuit, protocol):
         assert protocol.remote_interface() == circuit.endpoint_z
 
-    def test_backwards_circuit(self, circuit):
+    def test_backwards_circuit(self, circuit, bgp):
         """
         Make sure local/remote_interface returns the correct thing when the
         device is on the Z side of the circuit instead of the A side
@@ -101,8 +204,10 @@ class TestInterfaces(object):
         protocol = models.Protocol.objects.create(
             device=circuit.endpoint_z.device,
             circuit=circuit,
-            type='bgp',
-            asn=1234
+            type=bgp,
+            attributes={
+                'asn': '1234',
+            }
         )
 
         assert protocol.local_interface() == circuit.endpoint_z

--- a/tests/model_tests/test_protocols.py
+++ b/tests/model_tests/test_protocols.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import pytest
+from nsot import exc, models
+from .fixtures import circuit, site
+
+
+# Allow everything in there to access the DB
+pytestmark = pytest.mark.django_db
+
+
+class TestCreation(object):
+    @pytest.fixture
+    def device(self, circuit):
+        return circuit.endpoint_a.device
+
+    def test_normal_conditions(self, device, circuit):
+        """
+        Under normal conditions, ensure that a Protocol can be created without
+        raising any exceptions
+        """
+        protocol = models.Protocol.objects.create(
+            device=device,
+            circuit=circuit,
+            type='bgp',
+            asn=1234,
+            description='My fancy peer'
+        )
+
+        assert protocol.site_id == device.site_id
+        assert protocol in device.protocols.all()
+        assert protocol in circuit.protocols.all()
+
+    def test_bad_circuit(self, device, circuit):
+        """
+        Ensure a ValidationError is thrown when we try to create a Protocol
+        where the Circuit is not attached to the Device
+        """
+        bad_circuit = circuit
+        bad_circuit.endpoint_a = bad_circuit.endpoint_z
+
+        with pytest.raises(exc.ValidationError):
+            models.Protocol.objects.create(
+                device=device,
+                circuit=bad_circuit,
+                type='bgp',
+                asn=1234
+            )
+
+    def test_bad_type(self, device, circuit):
+        with pytest.raises(exc.ValidationError):
+            models.Protocol.objects.create(
+                device=device,
+                circuit=circuit,
+                type='oh no',
+                asn=1234
+            )
+
+    def test_attributes(self, device, circuit):
+        """ Ensure that we can set attributes on a Protocol """
+        models.Attribute.objects.create(
+            site=device.site, resource_name='Protocol', name='import_policies')
+
+        protocol = models.Protocol.objects.create(
+            device=device,
+            circuit=circuit,
+            type='bgp',
+            asn=1234,
+            attributes={
+                'import_policies': 'foo'
+            }
+        )
+
+        assert protocol.get_attributes()['import_policies'] == 'foo'
+
+
+class TestInterfaces(object):
+    @pytest.fixture
+    def protocol(self, circuit):
+        device = circuit.endpoint_a.device
+
+        return models.Protocol.objects.create(
+            device=device,
+            circuit=circuit,
+            type='bgp',
+            asn=1234
+        )
+
+    def test_local_interface(self, circuit, protocol):
+        assert protocol.local_interface() == circuit.endpoint_a
+
+    def test_remote_interface(self, circuit, protocol):
+        assert protocol.remote_interface() == circuit.endpoint_z
+
+    def test_backwards_circuit(self, circuit):
+        """
+        Make sure local/remote_interface returns the correct thing when the
+        device is on the Z side of the circuit instead of the A side
+        """
+        protocol = models.Protocol.objects.create(
+            device=circuit.endpoint_z.device,
+            circuit=circuit,
+            type='bgp',
+            asn=1234
+        )
+
+        assert protocol.local_interface() == circuit.endpoint_z
+        assert protocol.remote_interface() == circuit.endpoint_a


### PR DESCRIPTION
A Protocol represents a routing protocol which is running over a circuit, such as BGP, OSPF, IS-IS, etc.

This commit includes only the model, I will implement the CRUD operations later once this model is solidified.

This is based on some experimentation and the conversation in #206. There are both `interface` and `circuit` fields available to store information relevant to different routing protocols. 

For example, OSPF is generally assigned on a per-interface level, but BGP typically needs information like a remote peer address (the address on the remote Interface of the Circuit) and optionally an update source (the local Interface on the Circuit).

The concrete fields on `Protocol` are meant to cover all cases, any other parameters, for example a BGP ASN, are meant to be attributes that are added to a Protocol object. To help with validation for needed attributes, a ProtocolType object is added. On a `ProtocolType`, you can define attributes on `Protocol` which are required and if a `Protocol` is missing any of those attributes is saved, a `ValidationError` will get raised. 

The tests show some example uses of ProtocolType, but when all the view code is added I'll be sure to update the documentation with some 'cookbooks' how how exactly to use these objects with the API.