### PR TITLE
Fix #298 - Bugfix in circuit lookup using natural key for A/Z endpoint

### DIFF
--- a/nsot/api/filters.py
+++ b/nsot/api/filters.py
@@ -152,9 +152,34 @@ class InterfaceFilter(ResourceFilter):
 
 class CircuitFilter(ResourceFilter):
     """Filter for Circuit objects."""
+    endpoint_a = django_filters.MethodFilter()
+    endpoint_z = django_filters.MethodFilter()
+
     class Meta:
         model = models.Circuit
         fields = ['endpoint_a', 'endpoint_z', 'name', 'attributes']
+
+    # FIXME(jathan): The copy/pasted methods can be ripped out once we upgrade
+    # filters in support of the V2 API. For now this is quicker and easier.
+    def filter_endpoint_a(self, queryset, value):
+        """Overload to use natural key."""
+        if isinstance(value, int):
+            value = str(value)
+
+        if value.isdigit():
+            return queryset.filter(endpoint_a=value)
+        else:
+            return queryset.filter(endpoint_a__name_slug=value)
+
+    def filter_endpoint_z(self, queryset, value):
+        """Overload to use natural key."""
+        if isinstance(value, int):
+            value = str(value)
+
+        if value.isdigit():
+            return queryset.filter(endpoint_z=value)
+        else:
+            return queryset.filter(endpoint_z__name_slug=value)
 
 
 class ProtocolTypeFilter(django_filters.rest_framework.FilterSet):

--- a/tests/api_tests/test_circuits.py
+++ b/tests/api_tests/test_circuits.py
@@ -390,16 +390,28 @@ def test_filters(site, client):
     # Test filter by endpoint_a
     wanted = [cir2]
     expected = filter_circuits(circuits, wanted)
+    # by ID
     assert_success(
         client.retrieve(cir_uri, endpoint_a=if_a2['id']),
+        expected
+    )
+    # by natural key
+    assert_success(
+        client.retrieve(cir_uri, endpoint_a=if_a2['name_slug']),
         expected
     )
 
     # Test filter by endpoint_z
     wanted = [cir1]
     expected = filter_circuits(circuits, wanted)
+    # by ID
     assert_success(
         client.retrieve(cir_uri, endpoint_z=if_z1['id']),
+        expected
+    )
+    # by natural key
+    assert_success(
+        client.retrieve(cir_uri, endpoint_z=if_z1['name_slug']),
         expected
     )
 


### PR DESCRIPTION
This extends the `CircuitFilter` to have custom methods to filter by ID or natural key, which was overlooked when the `Circuit` feature was added.