### PR TITLE
Fix #267 - Disable /users route because view does not exist.

### DIFF
--- a/nsot/static/src/js/app.js
+++ b/nsot/static/src/js/app.js
@@ -101,10 +101,12 @@
             templateUrl: "index.html",
             controller: "IndexController"
         })
+        /*
         .when("/users", {
             templateUrl: "users.html",
             controller: "UsersController"
         })
+        */
         .when("/users/:userId", {
             templateUrl: "user.html",
             controller: "UserController"

--- a/nsot/templates/ui/menu.html
+++ b/nsot/templates/ui/menu.html
@@ -64,9 +64,11 @@
                         <li>
                             <a title="Sites" href="/sites"><i class="fa fa-fw fa-sitemap"></i> Sites</a>
                         </li>
+                        <!--
                         <li>
                             <a title="Users" href="/users"><i class="fa fa-fw fa-users"></i> Users</a>
                         </li>
+                        -->
                         <li class="divider"></li>
                         <li><a
                             title="API"


### PR DESCRIPTION
This just comments out `/users` from the app routes and from the settings menu in the web UI because the Users view does nothing and is confusing.