### PR TITLE
Update release docs to use twine since old method no longer works.

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -226,11 +226,13 @@ project maintainers, who have push access to the parent repository.
    just merged)
 #. Create a new git tag with this verison in the format of ``vX.Y.Z``
 #. Push up the new tag
-#. Create a new package and push it up to PyPI:
+#. Create a new package and push it up to PyPI (where ``{version}`` is the
+   current release version):
 
 .. code-block:: bash
 
-    $ python setup.py sdist upload
+    $ python setup.py sdist
+    $ twine upload dist/nsot-{version}.tar.gz
 
 .. _deprecation-policy:
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,4 +13,4 @@ pytest-pythonpath~=0.6.0
 Sphinx~=1.3.6
 sphinx-autobuild~=0.6.0
 sphinx-rtd-theme~=0.1.9
-twine=~1.9.1
+twine~=1.9.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,3 +13,4 @@ pytest-pythonpath~=0.6.0
 Sphinx~=1.3.6
 sphinx-autobuild~=0.6.0
 sphinx-rtd-theme~=0.1.9
+twine=~1.9.1


### PR DESCRIPTION
- The `requirements-dev.txt` file has also been updated to include
  twine.