### PR TITLE
Remove django-smart-selects from requirements.

### DIFF
--- a/nsot/conf/settings.py
+++ b/nsot/conf/settings.py
@@ -37,7 +37,6 @@ INSTALLED_APPS = (
     'django_extensions',
     'django_filters',
     'guardian',
-    'smart_selects',
     'rest_framework',
     'rest_framework_swagger',
     'custom_user',

--- a/nsot/conf/urls.py
+++ b/nsot/conf/urls.py
@@ -39,9 +39,6 @@ urlpatterns = [
         name='favicon'
     ),
 
-    # Smart selects chaining
-    url(r'^chaining/', include('smart_selects.urls')),
-
     # FE handlers
     # Catch index
     url(r'^$', FeView.as_view(), name='index'),

--- a/nsot/fields.py
+++ b/nsot/fields.py
@@ -9,14 +9,13 @@ from django_extensions.db.fields.json import JSONField
 from macaddress.fields import MACAddressField as BaseMACAddressField
 import ipaddress
 import logging
-from smart_selects.db_fields import ChainedForeignKey
 import types
 
 from . import exc
 
 
 __all__ = (
-    'BinaryIPAddressField', 'ChainedForeignKey', 'JSONField', 'MACAddressField'
+    'BinaryIPAddressField', 'JSONField', 'MACAddressField'
 )
 
 

--- a/nsot/migrations/0012_auto_20151002_1427.py
+++ b/nsot/migrations/0012_auto_20151002_1427.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
-import smart_selects.db_fields
 import django.db.models.deletion
 
 
@@ -26,7 +25,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='interface',
             name='parent',
-            field=smart_selects.db_fields.ChainedForeignKey(chained_model_field='device', related_name='children', on_delete=django.db.models.deletion.PROTECT, default=None, auto_choose=True, to='nsot.Interface', chained_field='device', blank=True, help_text='Unique ID of the parent Interface.', null=True, verbose_name='Parent'),
+            field=models.ForeignKey(related_name='children', on_delete=django.db.models.deletion.PROTECT, default=None, to='nsot.Interface', blank=True, help_text='Unique ID of the parent Interface.', null=True, verbose_name='Parent'),
         ),
         migrations.AlterField(
             model_name='interface',

--- a/nsot/migrations/0014_auto_20151002_1653.py
+++ b/nsot/migrations/0014_auto_20151002_1653.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
-import smart_selects.db_fields
 import django.db.models.deletion
 
 
@@ -16,6 +15,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='interface',
             name='parent',
-            field=smart_selects.db_fields.ChainedForeignKey(chained_model_field='device', related_name='children', on_delete=django.db.models.deletion.PROTECT, default=None, to='nsot.Interface', chained_field='device', blank=True, help_text='Unique ID of the parent Interface.', null=True, verbose_name='Parent'),
+            field=models.ForeignKey(related_name='children', on_delete=django.db.models.deletion.PROTECT, default=None, to='nsot.Interface', blank=True, help_text='Unique ID of the parent Interface.', null=True, verbose_name='Parent'),
         ),
     ]

--- a/nsot/migrations/0015_move_attribute_fields.py
+++ b/nsot/migrations/0015_move_attribute_fields.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
-import smart_selects.db_fields
 import django.db.models.deletion
 import django_extensions.db.fields.json
 import nsot.fields
@@ -111,7 +110,7 @@ class Migration(migrations.Migration):
                 ('speed', models.IntegerField(default=10000, help_text='Integer of Mbps of interface (e.g. 20000 for 20 Gbps). If not provided, defaults to 10000.', db_index=True, blank=True)),
                 ('addresses', models.ManyToManyField(related_name='addresses', through='nsot.Assignment_temp', to='nsot.Network_temp', db_index=True)),
                 ('device', models.ForeignKey(related_name='interfaces', verbose_name='Device', to='nsot.Device_temp', help_text='Unique ID of the connected Device.')),
-                ('parent', smart_selects.db_fields.ChainedForeignKey(chained_model_field='device', related_name='children', on_delete=django.db.models.deletion.PROTECT, default=None, auto_choose=True, to='nsot.Interface_temp', chained_field='device', blank=True, help_text='Unique ID of the parent Interface.', null=True, verbose_name='Parent')),
+                ('parent', models.ForeignKey(related_name='children', on_delete=django.db.models.deletion.PROTECT, default=None, to='nsot.Interface_temp', blank=True, help_text='Unique ID of the parent Interface.', null=True, verbose_name='Parent')),
                 ('site', models.ForeignKey(related_name='interfaces', on_delete=django.db.models.deletion.PROTECT, to='nsot.Site')),
             ],
         ),

--- a/nsot/migrations/0021_remove_resource_object.py
+++ b/nsot/migrations/0021_remove_resource_object.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 from django.db import models, migrations
 import django.db.models.deletion
 import django_extensions.db.fields.json
-import smart_selects.db_fields
 
 
 class Migration(migrations.Migration):
@@ -135,7 +134,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='interface',
             name='parent',
-            field=smart_selects.db_fields.ChainedForeignKey(chained_model_field='device', related_name='children', on_delete=django.db.models.deletion.PROTECT, default=None, to='nsot.Interface', chained_field='device', blank=True, help_text='Unique ID of the parent Interface.', null=True, verbose_name='Parent'),
+            field=models.ForeignKey(related_name='children', on_delete=django.db.models.deletion.PROTECT, default=None, to='nsot.Interface', blank=True, help_text='Unique ID of the parent Interface.', null=True, verbose_name='Parent'),
         ),
 
         ###############

--- a/nsot/models/interface.py
+++ b/nsot/models/interface.py
@@ -102,10 +102,9 @@ class Interface(Resource):
         )
     )
 
-    parent = fields.ChainedForeignKey(
+    parent = models.ForeignKey(
         'self', blank=True, null=True, related_name='children',
         default=None, db_index=True, on_delete=models.PROTECT,
-        chained_field='device', chained_model_field='device',
         verbose_name='Parent', help_text='Unique ID of the parent Interface.',
     )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ django-guardian~=1.4.9
 django-jinja~=1.4.1
 django-macaddress~=1.3.2
 django-rest-swagger~=0.3.5
-django-smart-selects~=1.3.0
 djangorestframework~=3.5.0
 djangorestframework-bulk~=0.2.1
 drf-extensions~=0.2.8


### PR DESCRIPTION
This dependency is no longer necessary. The database migrations that
referenced the `ChainedForeignKey` field were updated to swap it with a
regular `ForeignKey` field.

While it sounds bad, underneath the `ChainedForeignKey` field was still
just an FK with extra app-level behavior so reverting it to FK is really
a no-op from the perspective of the underlying db schema.