### PR TITLE
Use registry.bower.io for the Bower registry

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,5 +1,5 @@
 {
     "analytics": false,
-    "directory": "_bc"
+    "directory": "_bc",
+    "registry": "https://registry.bower.io"
 }
-


### PR DESCRIPTION
The registry domain has changed from `bower.herokuapp.com`:
https://gist.github.com/sheerun/c04d856a7a368bad2896ff0c4958cb00#gistcomment-2226585

The old `bower.herokuapp.com` domain is deprecated and returns HTTP 5xx errors, which breaks the `gulp build` part of the `setup.py sdist` process.