### PR TITLE
Make a mutable copy of the QueryDict before we try to update it

### DIFF
--- a/nsot/api/serializers.py
+++ b/nsot/api/serializers.py
@@ -155,6 +155,7 @@ class NsotSerializer(serializers.ModelSerializer):
             site_field = None
 
         if site_field not in data and 'site_pk' in kwargs:
+            data = data.copy()  # Get a mutable copy of the QueryDict
             data[site_field] = kwargs['site_pk']
 
         log.debug('NsotSerializer.to_internal_value() data [after] = %r', data)


### PR DESCRIPTION
When Django was upgraded to 1.11 in #321, the QueryDict that gets passed
into `NsotSerializer.to_internal_value()` became immutable. In cases
where the site ID would get set on that QeueryDict, this would cause an
exception to get thrown (modifying an immutable object).

This fixes that issue and makes a mutable copy of the QueryDict before
trying to set the site field.