### PR TITLE
Enhance set queries to support concrete fields issue 222

### DIFF
--- a/nsot/models/attribute.py
+++ b/nsot/models/attribute.py
@@ -152,8 +152,8 @@ class Attribute(models.Model):
         self.name = self.clean_name(self.name)
 
     def get_resource_class(self):
-        # TODO: Make this better!
-        # Wasn't sure on how to get the app name from django easily!
+        """This method returns the resource class that invoked the method"""
+
         return apps.get_model('nsot', self.resource_name)
 
     def _validate_single_value(self, value, constraints=None):

--- a/nsot/models/attribute.py
+++ b/nsot/models/attribute.py
@@ -140,8 +140,8 @@ class Attribute(models.Model):
 
         if value in concrete_field_names:
             raise exc.ValidationError({
-                'name': ('Attribute name %r cannot be the same as a'
-                        ' concrete field on %r' % (value, self.resource_name))
+                'name': ('Attribute name %r cannot be the same as a concrete'
+                         ' field on %r' % (value, self.resource_name))
             })
 
         if not settings.ATTRIBUTE_NAME.match(value):

--- a/nsot/models/attribute.py
+++ b/nsot/models/attribute.py
@@ -158,6 +158,7 @@ class Attribute(models.Model):
         self.name = self.clean_name(self.name)
 
     def _get_model_cls(self):
+        # TODO: Make this better!
         # Wasn't sure on how to get the app name from django easily!
         return apps.get_model('nsot', self.resource_name)
 

--- a/nsot/models/attribute.py
+++ b/nsot/models/attribute.py
@@ -141,7 +141,7 @@ class Attribute(models.Model):
         if value in concrete_field_names:
             raise exc.ValidationError({
                 'name': ('Attribute name %r cannot be the same as a'
-                    ' concrete field on %r' % (value, self.resource_name))
+                        ' concrete field on %r' % (value, self.resource_name))
             })
 
         if not settings.ATTRIBUTE_NAME.match(value):

--- a/nsot/models/attribute.py
+++ b/nsot/models/attribute.py
@@ -129,14 +129,8 @@ class Attribute(models.Model):
 
     def clean_name(self, value):
         value = validators.validate_name(value)
-        resource_cls = self._get_model_cls()
-
-        # Grabbing concrete fields from the resource class to check if the
-        # attr name is not a concrete field on the resource model object
-        concrete_field_names = []
-        concrete_fields = resource_cls._meta.concrete_fields
-        for field in concrete_fields:
-            concrete_field_names.append(field.name)
+        resource_cls = self.get_resource_cls()
+        concrete_field_names = resource_cls.get_concrete_field_names()
 
         if value in concrete_field_names:
             raise exc.ValidationError({
@@ -157,7 +151,7 @@ class Attribute(models.Model):
         self.resource_name = self.clean_resource_name(self.resource_name)
         self.name = self.clean_name(self.name)
 
-    def _get_model_cls(self):
+    def get_resource_class(self):
         # TODO: Make this better!
         # Wasn't sure on how to get the app name from django easily!
         return apps.get_model('nsot', self.resource_name)

--- a/nsot/models/attribute.py
+++ b/nsot/models/attribute.py
@@ -129,7 +129,7 @@ class Attribute(models.Model):
 
     def clean_name(self, value):
         value = validators.validate_name(value)
-        resource_cls = self.get_resource_cls()
+        resource_cls = self.get_resource_class()
         concrete_field_names = resource_cls.get_concrete_field_names()
 
         if value in concrete_field_names:

--- a/nsot/models/resource.py
+++ b/nsot/models/resource.py
@@ -277,15 +277,15 @@ class Resource(models.Model):
         self.attributes.all().delete()
 
     @classmethod
-    def get_concrete_field_names(self):
+    def get_concrete_field_names(cls):
         """Returns a list of the concrete field names as strings
         defined on the resource model"""
 
         # Grabbing the concrete fields for this Resource
         concrete_field_names = []
-        # The below call can be replaced with .get_concrete_fields_with_model()
-        # once we upgrade to >= 2.1
-        concrete_fields = self._meta.concrete_fields
+        # TODO(nseshan): The below call can be replaced with
+        # .get_concrete_fields_with_model() once we upgrade to >= 2.1
+        concrete_fields = cls._meta.concrete_fields
         for field in concrete_fields:
             concrete_field_names.append(field.name)
 

--- a/nsot/models/resource.py
+++ b/nsot/models/resource.py
@@ -107,8 +107,9 @@ class ResourceSetTheoryQuerySet(models.query.QuerySet):
                         **params
                     )
                 except Attribute.DoesNotExist as err:
-                    # If the query field is not an attribute, check if it is a concrete
-                    # field on the resource. If not, then raise the exception
+                    # If the query field is not an attribute, check if it is a
+                    # concrete field on the resource. If not, then raise
+                    # an exception
                     raise exc.ValidationError({
                         'query': '%s: %r' % (err.message.rstrip('.'), name)
                     })

--- a/tests/api_tests/test_devices.py
+++ b/tests/api_tests/test_devices.py
@@ -231,6 +231,31 @@ def test_set_queries(client, site):
     )
 
 
+def test_set_queries_with_concrete_fields(client, site):
+    """Test set queries that contain attrs as well as concrete_fields"""
+
+    # URIs
+    attr_uri = site.list_uri('attribute')
+    dev_uri = site.list_uri('device')
+    query_uri = site.query_uri('device')
+
+    # Pre-load the attributes
+    client.post(attr_uri, data=load('attributes.json'))
+
+    # Populate the device objects.
+    dev_resp = client.post(dev_uri, data=load('devices.json'))
+    devices = get_result(dev_resp)
+
+    # INTERSECTION: foo=bar owner=jathan hostname=foo-bar1
+    wanted = ['foo-bar1']
+    expected = filter_devices(devices, wanted)
+    assert_success(
+        client.retrieve(query_uri,
+            query='foo=bar owner=jathan hostname=foo-bar1'),
+        expected
+    )
+
+
 def test_update(client, user_client, user, site):
     """Test updating a device using pk."""
     # URIs

--- a/tests/api_tests/test_networks.py
+++ b/tests/api_tests/test_networks.py
@@ -321,6 +321,42 @@ def test_set_queries(client, site):
     )
 
 
+def test_set_queries_with_concrete_fields(client, site):
+    """Test filtering resources via set_queries using attrs
+    and concrete_fields"""
+
+    # URIs
+    attr_uri = site.list_uri('attribute')
+    net_uri = site.list_uri('network')
+    query_uri = site.query_uri('network')
+
+    # Pre-load the attributes
+    client.post(attr_uri, data=load('attributes.json'))
+
+    # Populate the network objects and retreive them for testing.
+    client.post(net_uri, data=load('networks.json'))
+    net_resp = client.retrieve(net_uri)
+    networks = get_result(net_resp)
+
+    # INTERSECTION: foo=bar owner=jathan prefix_length=16 ip_version=4
+    wanted = ['169.254.0.0/16']
+    expected = filter_networks(networks, wanted)
+    assert_success(
+        client.retrieve(query_uri,
+            query='foo=bar owner=jathan prefix_length=16 ip_version=4'),
+        expected
+    )
+
+    # INTERSECTION: foo=bar ip_version=4
+    wanted = ['10.0.0.0/8', '169.254.0.0/16']
+    expected = filter_networks(networks, wanted)
+    assert_success(
+        client.retrieve(query_uri,
+            query='foo=bar ip_version=4'),
+        expected
+    )
+
+
 def test_update(live_server, user, site):
     """Test updating Networks by pk and natural_key."""
     admin_client = Client(live_server, 'admin')

--- a/tests/model_tests/test_attributes.py
+++ b/tests/model_tests/test_attributes.py
@@ -48,11 +48,35 @@ def test_conflict(site):
         site=site, name='test_attribute_2'
     )
 
+
+def test_attr_creation_name_in_concrete_fields(site):
     with pytest.raises(exc.ValidationError):
         models.Attribute.objects.create(
             resource_name='Device',
             site=site, name='hostname'
         )
+
+
+def test_set_query_with_concrete_fields(site):
+    models.Attribute.objects.create(
+        site=site, resource_name='Network', name='test'
+    )
+    models.Network.objects.create(
+        site=site, cidr=u'10.0.0.0/24', attributes={'test': 'bar'}
+    )
+
+    assert list(models.Network.objects.set_query(
+        'test=bar prefix_length=24'))[0].cidr == '10.0.0.0/24'
+
+    models.Attribute.objects.create(
+        site=site, resource_name='Device', name='foo'
+    )
+    models.Device.objects.create(
+        site=site, hostname='foobar', attributes={'foo': 'bar'}
+    )
+
+    assert list(models.Device.objects.set_query(
+        'foo=bar hostname=foobar'))[0].hostname == 'foobar'
 
 
 def test_validation(site, transactional_db):

--- a/tests/model_tests/test_attributes.py
+++ b/tests/model_tests/test_attributes.py
@@ -48,7 +48,7 @@ def test_conflict(site):
         site=site, name='test_attribute_2'
     )
 
-    with pytest.raises(DjangoValidationError):
+    with pytest.raises(exc.ValidationError):
         models.Attribute.objects.create(
             resource_name='Device',
             site=site, name='hostname'

--- a/tests/model_tests/test_attributes.py
+++ b/tests/model_tests/test_attributes.py
@@ -48,6 +48,12 @@ def test_conflict(site):
         site=site, name='test_attribute_2'
     )
 
+    with pytest.raises(DjangoValidationError):
+        models.Attribute.objects.create(
+            resource_name='Device',
+            site=site, name='hostname'
+        )
+
 
 def test_validation(site, transactional_db):
     with pytest.raises(exc.ValidationError):


### PR DESCRIPTION
Summary of changes:

1. Added constraint on attr name, where it can no longer be the same as a concrete field on the resource that it's being created on

```
$ nsot attributes add -r Device -n hostname
[FAILURE] name: Attribute name u'hostname' cannot be the same as a concrete field on 'Device'
```

2. Added support for concrete fields within a set query

```
$ nsot networks list -q 'type=interconnect metro=foo ip_version=4'
10.207.6.0/23
10.207.8.0/28
$ nsot networks list -q 'type=interconnect metro=foo prefix_length=23'
10.207.6.0/23
$ nsot networks list -q 'type=interconnect metro=bar ip_version=6'
2001:5:4::/64
```