### PR TITLE
[Issue #261] Update Circuit addresses to enumerate addresses of all c…

### DIFF
--- a/nsot/models/attribute.py
+++ b/nsot/models/attribute.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import re
 
+from django.apps import apps
 from django.conf import settings
 from django.db import models
 
@@ -128,6 +129,14 @@ class Attribute(models.Model):
 
     def clean_name(self, value):
         value = validators.validate_name(value)
+        resource_cls = self.get_resource_class()
+        concrete_field_names = resource_cls.get_concrete_field_names()
+
+        if value in concrete_field_names:
+            raise exc.ValidationError({
+                'name': ('Attribute name %r cannot be the same as a concrete'
+                         ' field on %r' % (value, self.resource_name))
+            })
 
         if not settings.ATTRIBUTE_NAME.match(value):
             raise exc.ValidationError({
@@ -141,6 +150,11 @@ class Attribute(models.Model):
         self.display = self.clean_display(self.display)
         self.resource_name = self.clean_resource_name(self.resource_name)
         self.name = self.clean_name(self.name)
+
+    def get_resource_class(self):
+        """This method returns the resource class that invoked the method"""
+
+        return apps.get_model('nsot', self.resource_name)
 
     def _validate_single_value(self, value, constraints=None):
         if not isinstance(value, basestring):

--- a/nsot/models/circuit.py
+++ b/nsot/models/circuit.py
@@ -75,16 +75,8 @@ class Circuit(Resource):
 
     @property
     def addresses(self):
-        """Return addresses associated with this circuit. This includes addresses associated
-        with child interfaces."""
-        addresses = []
-        for interface in self.interfaces:
-            addresses.extend(interface.addresses.all())
-
-            # For each interface, get addresses of all child interfaces and extend the list.
-            for child in interface.children.all():
-                addresses.extend(child.addresses.all())
-
+        """Return addresses associated with this circuit."""
+        addresses = [a for i in self.interfaces for a in i.addresses.all()]
         return addresses
 
     @property

--- a/nsot/models/circuit.py
+++ b/nsot/models/circuit.py
@@ -75,8 +75,17 @@ class Circuit(Resource):
 
     @property
     def addresses(self):
-        """Return addresses associated with this circuit."""
-        addresses = [a for i in self.interfaces for a in i.addresses.all()]
+        """Return addresses associated with this circuit. This includes addresses
+        associated with child interfaces."""
+        addresses = []
+        for interface in self.interfaces:
+            addresses.extend(interface.addresses.all())
+
+            # For each interface, get addresses of all child interfaces and
+            # extend the list.
+            for child in interface.children.all():
+                addresses.extend(child.addresses.all())
+
         return addresses
 
     @property

--- a/nsot/models/circuit.py
+++ b/nsot/models/circuit.py
@@ -75,8 +75,16 @@ class Circuit(Resource):
 
     @property
     def addresses(self):
-        """Return addresses associated with this circuit."""
-        addresses = [a for i in self.interfaces for a in i.addresses.all()]
+        """Return addresses associated with this circuit. This includes addresses associated
+        with child interfaces."""
+        addresses = []
+        for interface in self.interfaces:
+            addresses.extend(interface.addresses.all())
+
+            # For each interface, get addresses of all child interfaces and extend the list.
+            for child in interface.children.all():
+                addresses.extend(child.addresses.all())
+
         return addresses
 
     @property

--- a/tests/api_tests/test_devices.py
+++ b/tests/api_tests/test_devices.py
@@ -231,6 +231,31 @@ def test_set_queries(client, site):
     )
 
 
+def test_set_queries_with_concrete_fields(client, site):
+    """Test set queries that contain attrs as well as concrete_fields"""
+
+    # URIs
+    attr_uri = site.list_uri('attribute')
+    dev_uri = site.list_uri('device')
+    query_uri = site.query_uri('device')
+
+    # Pre-load the attributes
+    client.post(attr_uri, data=load('attributes.json'))
+
+    # Populate the device objects.
+    dev_resp = client.post(dev_uri, data=load('devices.json'))
+    devices = get_result(dev_resp)
+
+    # INTERSECTION: foo=bar owner=jathan hostname=foo-bar1
+    wanted = ['foo-bar1']
+    expected = filter_devices(devices, wanted)
+    assert_success(
+        client.retrieve(query_uri,
+            query='foo=bar owner=jathan hostname=foo-bar1'),
+        expected
+    )
+
+
 def test_update(client, user_client, user, site):
     """Test updating a device using pk."""
     # URIs

--- a/tests/api_tests/test_networks.py
+++ b/tests/api_tests/test_networks.py
@@ -321,6 +321,42 @@ def test_set_queries(client, site):
     )
 
 
+def test_set_queries_with_concrete_fields(client, site):
+    """Test filtering resources via set_queries using attrs
+    and concrete_fields"""
+
+    # URIs
+    attr_uri = site.list_uri('attribute')
+    net_uri = site.list_uri('network')
+    query_uri = site.query_uri('network')
+
+    # Pre-load the attributes
+    client.post(attr_uri, data=load('attributes.json'))
+
+    # Populate the network objects and retreive them for testing.
+    client.post(net_uri, data=load('networks.json'))
+    net_resp = client.retrieve(net_uri)
+    networks = get_result(net_resp)
+
+    # INTERSECTION: foo=bar owner=jathan prefix_length=16 ip_version=4
+    wanted = ['169.254.0.0/16']
+    expected = filter_networks(networks, wanted)
+    assert_success(
+        client.retrieve(query_uri,
+            query='foo=bar owner=jathan prefix_length=16 ip_version=4'),
+        expected
+    )
+
+    # INTERSECTION: foo=bar ip_version=4
+    wanted = ['10.0.0.0/8', '169.254.0.0/16']
+    expected = filter_networks(networks, wanted)
+    assert_success(
+        client.retrieve(query_uri,
+            query='foo=bar ip_version=4'),
+        expected
+    )
+
+
 def test_update(live_server, user, site):
     """Test updating Networks by pk and natural_key."""
     admin_client = Client(live_server, 'admin')

--- a/tests/model_tests/test_circuits.py
+++ b/tests/model_tests/test_circuits.py
@@ -26,34 +26,24 @@ def test_creation(device):
         cidr='10.32.0.0/24', site=site,
     )
 
-    # A-side device/interface and child interface
+    # A-side device/interface
     device_a = device
     iface_a = models.Interface.objects.create(
-        device=device_a, name='ae0', addresses=['10.32.0.1/32']
-    )
-    child_iface_a = models.Interface.objects.create(
-        device=device_a, name='ae0.0', addresses=['10.32.0.3/32'], parent=iface_a
+        device=device_a, name='eth0/1', addresses=['10.32.0.1/32']
     )
 
-    # Z-side device/interface and child interface
+    # Z-side device/interface
     device_z = models.Device.objects.create(
         hostname='foo-bar2', site=site
     )
     iface_z = models.Interface.objects.create(
-        device=device_z, name='ae0', addresses=['10.32.0.2/32']
-    )
-    child_iface_z = models.Interface.objects.create(
-        device=device_z, name='ae0.0', addresses=['10.32.0.4/32'], parent=iface_z
+        device=device_z, name='eth0/1', addresses=['10.32.0.2/32']
     )
 
-    # Create the circuits
+    # Create the circuit
     circuit = models.Circuit.objects.create(
         endpoint_a=iface_a, endpoint_z=iface_z
     )
-    circuit_for_child_ifaces = models.Circuit.objects.create(
-        endpoint_a=child_iface_a, endpoint_z=child_iface_z
-    )
-
 
     # Interface inherits endpoint_a's site
     assert circuit.site == iface_a.site
@@ -70,8 +60,7 @@ def test_creation(device):
 
     # Assert property values
     assert circuit.interfaces == [iface_a, iface_z]
-    assert [str(a) for a in circuit.addresses] == ['10.32.0.1/32', '10.32.0.3/32', \
-                                                   '10.32.0.2/32', '10.32.0.4/32']
+    assert [str(a) for a in circuit.addresses] == ['10.32.0.1/32', '10.32.0.2/32']
     assert circuit.devices == [device_a, device_z]
 
     # Try to create another circuit w/ the same interfaces (expecting Django

--- a/tests/model_tests/test_circuits.py
+++ b/tests/model_tests/test_circuits.py
@@ -26,24 +26,34 @@ def test_creation(device):
         cidr='10.32.0.0/24', site=site,
     )
 
-    # A-side device/interface
+    # A-side device/interface and child interface
     device_a = device
     iface_a = models.Interface.objects.create(
-        device=device_a, name='eth0/1', addresses=['10.32.0.1/32']
+        device=device_a, name='ae0', addresses=['10.32.0.1/32']
+    )
+    child_iface_a = models.Interface.objects.create(
+        device=device_a, name='ae0.0', addresses=['10.32.0.3/32'], parent=iface_a
     )
 
-    # Z-side device/interface
+    # Z-side device/interface and child interface
     device_z = models.Device.objects.create(
         hostname='foo-bar2', site=site
     )
     iface_z = models.Interface.objects.create(
-        device=device_z, name='eth0/1', addresses=['10.32.0.2/32']
+        device=device_z, name='ae0', addresses=['10.32.0.2/32']
+    )
+    child_iface_z = models.Interface.objects.create(
+        device=device_z, name='ae0.0', addresses=['10.32.0.4/32'], parent=iface_z
     )
 
-    # Create the circuit
+    # Create the circuits
     circuit = models.Circuit.objects.create(
         endpoint_a=iface_a, endpoint_z=iface_z
     )
+    circuit_for_child_ifaces = models.Circuit.objects.create(
+        endpoint_a=child_iface_a, endpoint_z=child_iface_z
+    )
+
 
     # Interface inherits endpoint_a's site
     assert circuit.site == iface_a.site
@@ -60,7 +70,8 @@ def test_creation(device):
 
     # Assert property values
     assert circuit.interfaces == [iface_a, iface_z]
-    assert [str(a) for a in circuit.addresses] == ['10.32.0.1/32', '10.32.0.2/32']
+    assert [str(a) for a in circuit.addresses] == ['10.32.0.1/32', '10.32.0.3/32', \
+                                                   '10.32.0.2/32', '10.32.0.4/32']
     assert circuit.devices == [device_a, device_z]
 
     # Try to create another circuit w/ the same interfaces (expecting Django


### PR DESCRIPTION
**What this diff addresses**
This diff addresses Issue #261. I have added support to enumerate all address for all child interfaces. I have also adjusted the unit tests to test that this works as expected.

**See it in action**
For the following interfaces: 

```
+----------------------------------------------------------------------------+
| ID   Name (Key)        Parent          MAC    Addresses         Attributes |
+----------------------------------------------------------------------------+
| 6    foo1-bb01:ae0     None            None   185.45.19.10/32              |
|                                               185.45.19.8/32               |
| 7    foo1-bb02:ae0     None            None                                |
| 8    foo1-bb01:ae0.0   foo1-bb01:ae0   None   185.45.19.6/32               |
| 9    foo1-bb02:ae0.0   foo1-bb02:ae0   None   185.45.19.7/32               |
|                                               185.45.19.5/32               |
+----------------------------------------------------------------------------+
```

The list of addresses would be a list of its own addresses, appended by all addresses of each child interface.

```
In [1]: circuits = Circuit.objects.all()

In [2]: circuits
Out[2]: <ResourceSetTheoryQuerySet [<Circuit: foo1-bb01:ae0_foo1-bb02:ae0>, <Circuit: foo1-bb01:ae0.0_foo1-bb02:ae0.0>]>

In [3]: circuit_of_parent_ifaces = circuits[0]

In [4]: circuit_of_parent_ifaces.addresses
Out[4]:
[<Network: 185.45.19.10/32>,
 <Network: 185.45.19.8/32>,
 <Network: 185.45.19.6/32>,
 <Network: 185.45.19.7/32>,
 <Network: 185.45.19.5/32>]
``` 

Note that the first two are addresses are associated with the circuit's a side interface, the third is the address associated with child interface on the a side, and the last two with the child interface on the z side.

**TESTING**

```(env)(develop)$ pytest test_circuits.py
================================================================================ test session starts ================================================================================
platform linux2 -- Python 2.7.12, pytest-3.4.2, py-1.5.4, pluggy-0.6.0 -- /home/khardson/src/nsot/env/bin/python2
cachedir: ../../.pytest_cache
Django settings: tests.test_settings (from ini file)
Using NSoT API version: None
rootdir: /home/khardson/src/nsot/nsot, inifile: pytest.ini
plugins: django-3.1.2, pythonpath-0.6
collected 6 items

test_circuits.py::test_creation PASSED                                                                                                                                        [ 16%]
test_circuits.py::test_attributes PASSED                                                                                                                                      [ 33%]
test_circuits.py::TestInterfaceFor::test_normal_conditions PASSED                                                                                                             [ 50%]
test_circuits.py::TestInterfaceFor::test_single_sided PASSED                                                                                                                  [ 66%]
test_circuits.py::TestInterfaceFor::test_looped_circuit PASSED                                                                                                                [ 83%]
test_circuits.py::TestInterfaceFor::test_bogus_device PASSED                                                                                                                  [100%]

============================================================================= 6 passed in 3.56 seconds ==============================================================================```
