### PR TITLE
[Issue #261] Update Circuit addresses to enumerate addresses of all child interfaces

### DIFF
--- a/nsot/models/circuit.py
+++ b/nsot/models/circuit.py
@@ -75,13 +75,14 @@ class Circuit(Resource):
 
     @property
     def addresses(self):
-        """Return addresses associated with this circuit. This includes addresses associated
-        with child interfaces."""
+        """Return addresses associated with this circuit. This includes addresses
+        associated with child interfaces."""
         addresses = []
         for interface in self.interfaces:
             addresses.extend(interface.addresses.all())
 
-            # For each interface, get addresses of all child interfaces and extend the list.
+            # For each interface, get addresses of all child interfaces and
+            # extend the list.
             for child in interface.children.all():
                 addresses.extend(child.addresses.all())
 

--- a/nsot/models/circuit.py
+++ b/nsot/models/circuit.py
@@ -75,8 +75,16 @@ class Circuit(Resource):
 
     @property
     def addresses(self):
-        """Return addresses associated with this circuit."""
-        addresses = [a for i in self.interfaces for a in i.addresses.all()]
+        """Return addresses associated with this circuit. This includes addresses associated
+        with child interfaces."""
+        addresses = []
+        for interface in self.interfaces:
+            addresses.extend(interface.addresses.all())
+
+            # For each interface, get addresses of all child interfaces and extend the list.
+            for child in interface.children.all():
+                addresses.extend(child.addresses.all())
+
         return addresses
 
     @property

--- a/tests/model_tests/test_circuits.py
+++ b/tests/model_tests/test_circuits.py
@@ -26,24 +26,34 @@ def test_creation(device):
         cidr='10.32.0.0/24', site=site,
     )
 
-    # A-side device/interface
+    # A-side device/interface and child interface
     device_a = device
     iface_a = models.Interface.objects.create(
-        device=device_a, name='eth0/1', addresses=['10.32.0.1/32']
+        device=device_a, name='ae0', addresses=['10.32.0.1/32']
+    )
+    child_iface_a = models.Interface.objects.create(
+        device=device_a, name='ae0.0', addresses=['10.32.0.3/32'], parent=iface_a
     )
 
-    # Z-side device/interface
+    # Z-side device/interface and child interface
     device_z = models.Device.objects.create(
         hostname='foo-bar2', site=site
     )
     iface_z = models.Interface.objects.create(
-        device=device_z, name='eth0/1', addresses=['10.32.0.2/32']
+        device=device_z, name='ae0', addresses=['10.32.0.2/32']
+    )
+    child_iface_z = models.Interface.objects.create(
+        device=device_z, name='ae0.0', addresses=['10.32.0.4/32'], parent=iface_z
     )
 
-    # Create the circuit
+    # Create the circuits
     circuit = models.Circuit.objects.create(
         endpoint_a=iface_a, endpoint_z=iface_z
     )
+    circuit_for_child_ifaces = models.Circuit.objects.create(
+        endpoint_a=child_iface_a, endpoint_z=child_iface_z
+    )
+
 
     # Interface inherits endpoint_a's site
     assert circuit.site == iface_a.site
@@ -60,7 +70,8 @@ def test_creation(device):
 
     # Assert property values
     assert circuit.interfaces == [iface_a, iface_z]
-    assert [str(a) for a in circuit.addresses] == ['10.32.0.1/32', '10.32.0.2/32']
+    assert [str(a) for a in circuit.addresses] == ['10.32.0.1/32', '10.32.0.3/32', \
+                                                   '10.32.0.2/32', '10.32.0.4/32']
     assert circuit.devices == [device_a, device_z]
 
     # Try to create another circuit w/ the same interfaces (expecting Django


### PR DESCRIPTION
**What this diff addresses**
This diff addresses Issue #261. I have added support to enumerate addresses for all child interfaces. I have also adjusted the unit tests to test that this works as expected.

**See it in action**
For the following interfaces: 

```
+----------------------------------------------------------------------------+
| ID   Name (Key)        Parent          MAC    Addresses         Attributes |
+----------------------------------------------------------------------------+
| 6    foo1-bb01:ae0     None            None   185.45.21.10/32              |
|                                               185.45.21.8/32               |
| 7    foo1-bb02:ae0     None            None                                |
| 8    foo1-bb01:ae0.0   foo1-bb01:ae0   None   185.45.21.6/32               |
| 9    foo1-bb02:ae0.0   foo1-bb02:ae0   None   185.45.21.7/32               |
|                                               185.45.21.5/32               |
+----------------------------------------------------------------------------+
```

The list of addresses would be a list of its own addresses, appended by all addresses of each child interface.

```
In [1]: circuits = Circuit.objects.all()

In [2]: circuits
Out[2]: <ResourceSetTheoryQuerySet [<Circuit: foo1-bb01:ae0_foo1-bb02:ae0>, <Circuit: foo1-bb01:ae0.0_foo1-bb02:ae0.0>]>

In [3]: circuit_of_parent_ifaces = circuits[0]

In [4]: circuit_of_parent_ifaces.addresses
Out[4]:
[<Network: 185.45.21.10/32>,
 <Network: 185.45.21.8/32>,
 <Network: 185.45.21.6/32>,
 <Network: 185.45.21.7/32>,
 <Network: 185.45.21.5/32>]
``` 

Note that the first two are addresses are associated with the circuit's a side interface, the third is the address associated with child interface on the a side, and the last two with the child interface on the z side.

**TESTING**

```(env)(develop)$ pytest test_circuits.py
================================================================================ test session starts ================================================================================
platform linux2 -- Python 2.7.12, pytest-3.4.2, py-1.5.4, pluggy-0.6.0 -- /home/khardson/src/nsot/env/bin/python2
cachedir: ../../.pytest_cache
Django settings: tests.test_settings (from ini file)
Using NSoT API version: None
rootdir: /home/khardson/src/nsot/nsot, inifile: pytest.ini
plugins: django-3.1.2, pythonpath-0.6
collected 6 items

test_circuits.py::test_creation PASSED                                                                                                                                        [ 16%]
test_circuits.py::test_attributes PASSED                                                                                                                                      [ 33%]
test_circuits.py::TestInterfaceFor::test_normal_conditions PASSED                                                                                                             [ 50%]
test_circuits.py::TestInterfaceFor::test_single_sided PASSED                                                                                                                  [ 66%]
test_circuits.py::TestInterfaceFor::test_looped_circuit PASSED                                                                                                                [ 83%]
test_circuits.py::TestInterfaceFor::test_bogus_device PASSED                                                                                                                  [100%]

============================================================================= 6 passed in 3.56 seconds ==============================================================================```
