### PR TITLE
[Issue 121] Enabling forceful parent deletion

### DIFF
--- a/nsot/api/views.py
+++ b/nsot/api/views.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals
 from collections import namedtuple, OrderedDict
-import json
 import logging
 import warnings
 

--- a/nsot/api/views.py
+++ b/nsot/api/views.py
@@ -288,11 +288,14 @@ class NsotViewSet(BaseNsotViewSet, viewsets.ModelViewSet):
         change = models.Change.objects.create(
             obj=instance, user=self.request.user, event='Delete'
         )
-        data = json.loads(self.request.query_params.get('data'))
-        force_delete = qpbool(data.get('force', 'False'))
         try:
             instance.delete()
         except exc.ProtectedError as err:
+            force_delete = False
+            data = self.request.query_params.get('data', '')
+            if data:
+                data = json.loads(data)
+                force_delete = qpbool(data.get('force'))
             if force_delete:
                 new_parent = instance.parent
                 # Check if the network does not have a parent, check that it's

--- a/nsot/api/views.py
+++ b/nsot/api/views.py
@@ -295,16 +295,18 @@ class NsotViewSet(BaseNsotViewSet, viewsets.ModelViewSet):
         except exc.ProtectedError as err:
             if force_delete:
                 new_parent = instance.parent
-                # Check if the network does not have a parent, check that it's children are not
-                # leaf nodes. If so, raise an error.
+                # Check if the network does not have a parent, check that it's
+                # children are not leaf nodes. If so, raise an error.
                 if not new_parent:
                     children = instance.get_children()
                     for child in children:
                         if child.is_leaf_node():
-                            raise exc.Conflict('You cannot forcefully delete a network ' \
-                                'that does not have a parent, and whose children are leaf nodes.')
-                # Otherwise, update all children to use the new parent and delete the old parent
-                # of these child nodes.
+                            raise exc.Conflict('You cannot forcefully delete a'
+                                               ' network that does not have a'
+                                               ' parent, and whose children'
+                                               ' are leaf nodes.')
+                # Otherwise, update all children to use the new parent and
+                # delete the old parent of these child nodes.
                 err.protected_objects.update(parent=new_parent)
                 models.Network.objects.filter(pk=instance.pk).delete()
             else:

--- a/nsot/api/views.py
+++ b/nsot/api/views.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 from collections import namedtuple, OrderedDict
+import json
 import logging
 import warnings
 
@@ -287,12 +288,28 @@ class NsotViewSet(BaseNsotViewSet, viewsets.ModelViewSet):
         change = models.Change.objects.create(
             obj=instance, user=self.request.user, event='Delete'
         )
-
+        data = json.loads(self.request.query_params.get('data', ''))
+        force_delete = qpbool(data.get('force', False))
         try:
             instance.delete()
         except exc.ProtectedError as err:
-            change.delete()
-            raise exc.Conflict(err.args[0])
+            if force_delete:
+                new_parent = instance.parent
+                # Check if the network does not have a parent, check that it's children are not
+                # leaf nodes. If so, raise an error.
+                if not new_parent:
+                    children = instance.get_children()
+                    for child in children:
+                        if child.is_leaf_node():
+                            raise exc.ProtectedError("""You cannot forcefully delete a network
+                                that does not have a parent, and whose children are leaf nodes.""")
+                # Otherwise, update all children to use the new parent and delete the old parent
+                # of these child nodes.
+                err.protected_objects.update(parent=new_parent)
+                models.Network.objects.filter(pk=instance.pk).delete()
+        else:
+                change.delete()
+                raise exc.Conflict(err.args[0])
 
 
 class SiteViewSet(NsotViewSet):
@@ -340,7 +357,6 @@ class ResourceViewSet(NsotBulkUpdateModelMixin, NsotViewSet,
         """Perform a set query."""
         query = request.query_params.get('query', '')
         unique = qpbool(request.query_params.get('unique', False))
-
         qs = self.queryset.set_query(query, site_id=site_pk, unique=unique)
         objects = self.filter_queryset(qs)
         return self.list(request, queryset=objects, *args, **kwargs)

--- a/nsot/api/views.py
+++ b/nsot/api/views.py
@@ -288,14 +288,13 @@ class NsotViewSet(BaseNsotViewSet, viewsets.ModelViewSet):
         change = models.Change.objects.create(
             obj=instance, user=self.request.user, event='Delete'
         )
+        force_delete = qpbool(
+            self.request.query_params.get('force_delete', False)
+        )
+
         try:
             instance.delete()
         except exc.ProtectedError as err:
-            force_delete = False
-            data = self.request.query_params.get('data', '')
-            if data:
-                data = json.loads(data)
-                force_delete = qpbool(data.get('force'))
             if force_delete:
                 new_parent = instance.parent
                 # Check if the network does not have a parent, check that it's

--- a/tests/api_tests/test_networks.py
+++ b/tests/api_tests/test_networks.py
@@ -507,11 +507,10 @@ def test_force_deletion(site, client):
         - force delete /23 should raise an error.
     """
     # Delete /24 will fail, because it has a child.
-    resp = client.destroy(net3_obj_uri, data=json.dumps({'force': False}))
-    assert_error(resp, status.HTTP_409_CONFLICT)
+    assert_error(client.destroy(net3_obj_uri), status.HTTP_409_CONFLICT)
 
     # Forcefully delete the /24
-    assert_deleted(client.destroy(net3_obj_uri, data=json.dumps({'force': True})))
+    assert_deleted(client.destroy(net3_obj_uri, force_delete=True))
 
     # Fetching the /32 should match the original payload
     assert_success(client.retrieve(net2_obj_uri), net2)
@@ -526,12 +525,11 @@ def test_force_deletion(site, client):
     assert_success(client.retrieve(slash23_parent_uri), quad0)
 
     # Force delete quad0 and /23 parent should be null
-    client.destroy(quad0_obj_uri, data=json.dumps({'force': True}))
+    client.destroy(quad0_obj_uri, force_delete=True)
     assert_error(client.retrieve(slash23_parent_uri), status.HTTP_404_NOT_FOUND)
 
     # Force delete /23 will fail, because it has no parent and children are leaf nodes.
-    resp = client.destroy(net1_obj_uri, data=json.dumps({'force': True}))
-    assert_error(resp, status.HTTP_409_CONFLICT)
+    assert_error(client.destroy(net1_obj_uri, force_delete=True), status.HTTP_409_CONFLICT)
 
 
 def test_mptt_detail_routes(site, client):

--- a/tests/api_tests/test_networks.py
+++ b/tests/api_tests/test_networks.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 
 import pytest
-import json
 
 # Allow everything in there to access the DB
 pytestmark = pytest.mark.django_db

--- a/tests/api_tests/util.py
+++ b/tests/api_tests/util.py
@@ -177,6 +177,9 @@ class Client(object):
     def retrieve(self, url, **kwargs):
         return self.get(url, params=kwargs)
 
+    def destroy(self, url, **kwargs):
+        return self.delete(url, params=kwargs)
+
 
 def load_json(relpath):
     """


### PR DESCRIPTION
This issue is a safe guard for a situation where someone accidentally adds a parent. 

**Scenario #1: Mistakably adding a top level network**
Before this change, a situation of adding a quad0 would have been impossible to revert. Let's explore what this would look like:
```
$ nsot networks add --cidr=0.0.0.0/0
[SUCCESS] Added network!
```
Oops, now the `/24` now has quad0 as it's parent (and all other parent networks would as well):
```
$ nsot networks list
+-----------------------------------------------------------------------------------+
| ID   CIDR (Key)        Is IP?   IP Ver.   Parent           State       Attributes |
+-----------------------------------------------------------------------------------+
| 1    185.45.19.0/24    False    4         0.0.0.0/0        allocated              |
| 7    185.45.19.5/32    True     4         185.45.19.0/24   assigned               |
| 8    185.45.19.6/32    True     4         185.45.19.0/24   assigned               |
| 9    185.45.19.7/32    True     4         185.45.19.0/24   assigned               |
| 10   185.45.19.10/32   True     4         185.45.19.0/24   assigned               |
| 11   185.45.19.8/32    True     4         185.45.19.0/24   assigned               |
| 17   0.0.0.0/0         False    4         None             allocated              |
+-----------------------------------------------------------------------------------+
```
Notice that simply running `remove` raises an error:
```
$ nsot networks remove -i 17
[FAILURE] Cannot delete some instances of model 'Network' because they are referenced through a protected foreign key: 'Network.parent'
```
Enter the force-delete flag! The force-delete flag (added in this [pynsot PR](https://github.com/dropbox/pynsot/pull/160)) overrides the native django PROTECT method on `Network.parent`. Forceful deletion allows us to forcefully delete a network that has children:
```
$ nsot networks remove -i 17 --force-delete
[SUCCESS] Removed network!
```
Notice that the `/24` no longer has a parent:
```
$ nsot networks list
+-----------------------------------------------------------------------------------+
| ID   CIDR (Key)        Is IP?   IP Ver.   Parent           State       Attributes |
+-----------------------------------------------------------------------------------+
| 1    185.45.19.0/24    False    4         None             allocated              |
| 7    185.45.19.5/32    True     4         185.45.19.0/24   assigned               |
| 8    185.45.19.6/32    True     4         185.45.19.0/24   assigned               |
| 9    185.45.19.7/32    True     4         185.45.19.0/24   assigned               |
| 10   185.45.19.10/32   True     4         185.45.19.0/24   assigned               |
| 11   185.45.19.8/32    True     4         185.45.19.0/24   assigned               |
+-----------------------------------------------------------------------------------+
```

**Scenario #2: Deleting a parent with child leaf nodes**
Forceful deletion does not work when trying to delete a parent network whose children are leaf nodes:
```
$ nsot networks remove -i 1 --force-delete
[FAILURE] You cannot forcefully delete a network that does not have a parent, and whose children are leaf nodes.
```

**Scenario #3: Deleting a network that has a parent**
In a scenario where we try to delete a network that has a parent, the children of that network will be reparented to the deleted network's parent.

Notice we've added a new network: `185.45.0.0/17`, which is now the parent of `185.45.19.0/24`:
```
$ nsot networks list
+-----------------------------------------------------------------------------------+
| ID   CIDR (Key)        Is IP?   IP Ver.   Parent           State       Attributes |
+-----------------------------------------------------------------------------------+
| 1    185.45.19.0/24    False    4         185.45.0.0/17    allocated              |
| 7    185.45.19.5/32    True     4         185.45.19.0/24   assigned               |
| 8    185.45.19.6/32    True     4         185.45.19.0/24   assigned               |
| 9    185.45.19.7/32    True     4         185.45.19.0/24   assigned               |
| 10   185.45.19.10/32   True     4         185.45.19.0/24   assigned               |
| 11   185.45.19.8/32    True     4         185.45.19.0/24   assigned               |
| 19   185.45.0.0/17     False    4         None             allocated              |
+-----------------------------------------------------------------------------------+
```
Now let's try to delete `185.45.19.0/24`:
```
$ nsot networks remove -i 1
[FAILURE] Cannot delete some instances of model 'Network' because they are referenced through a protected foreign key: 'Network.parent'
```
It fails, as expected. Now let's try with the force-delete flag:
```
$ nsot networks remove -i 1 --force-delete
[SUCCESS] Removed network!
```
Notice all children have now been reparented to `185.45.0.0/17`.
```
$ nsot networks list
+----------------------------------------------------------------------------------+
| ID   CIDR (Key)        Is IP?   IP Ver.   Parent          State       Attributes |
+----------------------------------------------------------------------------------+
| 7    185.45.19.5/32    True     4         185.45.0.0/17   assigned               |
| 8    185.45.19.6/32    True     4         185.45.0.0/17   assigned               |
| 9    185.45.19.7/32    True     4         185.45.0.0/17   assigned               |
| 10   185.45.19.10/32   True     4         185.45.0.0/17   assigned               |
| 11   185.45.19.8/32    True     4         185.45.0.0/17   assigned               |
| 19   185.45.0.0/17     False    4         None            allocated              |
+----------------------------------------------------------------------------------+
```