### PR TITLE
Revert "Enhance set queries to support concrete fields issue 222"

### DIFF
--- a/nsot/models/attribute.py
+++ b/nsot/models/attribute.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 import re
 
-from django.apps import apps
 from django.conf import settings
 from django.db import models
 
@@ -129,14 +128,6 @@ class Attribute(models.Model):
 
     def clean_name(self, value):
         value = validators.validate_name(value)
-        resource_cls = self.get_resource_class()
-        concrete_field_names = resource_cls.get_concrete_field_names()
-
-        if value in concrete_field_names:
-            raise exc.ValidationError({
-                'name': ('Attribute name %r cannot be the same as a concrete'
-                         ' field on %r' % (value, self.resource_name))
-            })
 
         if not settings.ATTRIBUTE_NAME.match(value):
             raise exc.ValidationError({
@@ -150,11 +141,6 @@ class Attribute(models.Model):
         self.display = self.clean_display(self.display)
         self.resource_name = self.clean_resource_name(self.resource_name)
         self.name = self.clean_name(self.name)
-
-    def get_resource_class(self):
-        """This method returns the resource class that invoked the method"""
-
-        return apps.get_model('nsot', self.resource_name)
 
     def _validate_single_value(self, value, constraints=None):
         if not isinstance(value, basestring):

--- a/nsot/models/resource.py
+++ b/nsot/models/resource.py
@@ -40,17 +40,16 @@ class ResourceSetTheoryQuerySet(models.query.QuerySet):
             objects = objects.filter(site=site_id)
 
         try:
-            query_fields = util.parse_set_query(query)
+            attributes = util.parse_set_query(query)
         except (ValueError, TypeError) as err:
             raise exc.ValidationError({
                 'query': err.message
             })
 
         resource_name = self.model.__name__
-        concrete_field_names = self.model.get_concrete_field_names()
 
         # If there aren't any parsed attributes, don't return anything.
-        if not query_fields:
+        if not attributes:
             if unique:
                 raise exc.ValidationError({
                     'query': 'Query empty, unable to provide %s'
@@ -61,7 +60,7 @@ class ResourceSetTheoryQuerySet(models.query.QuerySet):
         # Iterate a/v pairs and combine query results using MySQL-compatible
         # set operations w/ the ORM
         log.debug('QUERY [start]: objects = %r', objects)
-        for action, name, value in query_fields:
+        for action, name, value in attributes:
             # Is this a regex pattern?
             regex_query = False
             if name.endswith('_regex'):
@@ -70,75 +69,40 @@ class ResourceSetTheoryQuerySet(models.query.QuerySet):
                 log.debug('Regex enabled for %r' % name)
 
             # Attribute lookup params
-            if name not in concrete_field_names:
-                params = dict(
-                    name=name, resource_name=resource_name
-                )
-            else:
-                params = dict()
-                params[name] = value
+            params = dict(
+                name=name, resource_name=resource_name
+            )
             # Only include site_id if it's set
             if site_id is not None:
                 params['site_id'] = site_id
 
             # If an Attribute doesn't exist, the set query is invalid. Return
             # an empty queryset. (fix #99)
-            if name not in concrete_field_names:
-                try:
-                    qfield = Attribute.objects.get(
-                        **params
-                    )
-                except Attribute.DoesNotExist as err:
-                    # If the query field is not an attribute, check if it is a
-                    # concrete field on the resource. If not, then raise
-                    # an exception
-                    raise exc.ValidationError({
-                        'query': '%s: %r' % (err.message.rstrip('.'), name)
-                    })
-            else:
-                try:
-                    qfield = self.model.objects.filter(
-                        **params
-                    )
-                except self.model.DoesNotExist as err:
-                    raise exc.ValidationError({
-                        'query': '%s: %r' % (err.message.rstrip('.'), name)
-                    })
+            try:
+                attr = Attribute.objects.get(
+                    **params
+                )
+            except Attribute.DoesNotExist as err:
+                raise exc.ValidationError({
+                    'query': '%s: %r' % (err.message.rstrip('.'), name)
+                })
 
             # Set lookup params
-            # Based on the above code block, qfield will only contain a
-            # `.name` in the case we're evaluating Attributes. For concrete
-            # fields, we only need the value of the field being evaluated.
-            if name not in concrete_field_names:
-                next_set_params = {
-                    'name': qfield.name,
-                    'value': value,
-                    'resource_name': resource_name
-                }
-            else:
-                next_set_params = {
-                    name: value
-                }
+            next_set_params = {
+                'name': attr.name,
+                'value': value,
+                'resource_name': resource_name
+            }
 
             # If it's a regex query, swap ``value`` with ``value__regex``.
             if regex_query:
                 next_set_params['value__regex'] = next_set_params.pop('value')
 
-            # If querying for an attribute object, we filter on
-            # ``resource_id`` on the results obtained. For concrete fields,
-            # we need to filter based on pk, ie, ``id``.
-            if name not in concrete_field_names:
-                next_set = Q(
-                    id__in=Value.objects.filter(
-                        **next_set_params
-                    ).values_list('resource_id', flat=True)
-                )
-            else:
-                next_set = Q(
-                    id__in=self.model.objects.filter(
-                        **next_set_params
-                    ).values_list('id', flat=True)
-                )
+            next_set = Q(
+                id__in=Value.objects.filter(
+                    **next_set_params
+                ).values_list('resource_id', flat=True)
+            )
 
             # This is the MySQL-compatible manual implementation of set theory,
             # baby!
@@ -275,21 +239,6 @@ class Resource(models.Model):
 
     def _purge_attribute_index(self):
         self.attributes.all().delete()
-
-    @classmethod
-    def get_concrete_field_names(cls):
-        """Returns a list of the concrete field names as strings
-        defined on the resource model"""
-
-        # Grabbing the concrete fields for this Resource
-        concrete_field_names = []
-        # TODO(nseshan): The below call can be replaced with
-        # .get_concrete_fields_with_model() once we upgrade to >= 2.1
-        concrete_fields = cls._meta.concrete_fields
-        for field in concrete_fields:
-            concrete_field_names.append(field.name)
-
-        return concrete_field_names
 
     def get_attributes(self):
         """Return the JSON-encoded attributes as a dict."""

--- a/tests/api_tests/test_devices.py
+++ b/tests/api_tests/test_devices.py
@@ -231,31 +231,6 @@ def test_set_queries(client, site):
     )
 
 
-def test_set_queries_with_concrete_fields(client, site):
-    """Test set queries that contain attrs as well as concrete_fields"""
-
-    # URIs
-    attr_uri = site.list_uri('attribute')
-    dev_uri = site.list_uri('device')
-    query_uri = site.query_uri('device')
-
-    # Pre-load the attributes
-    client.post(attr_uri, data=load('attributes.json'))
-
-    # Populate the device objects.
-    dev_resp = client.post(dev_uri, data=load('devices.json'))
-    devices = get_result(dev_resp)
-
-    # INTERSECTION: foo=bar owner=jathan hostname=foo-bar1
-    wanted = ['foo-bar1']
-    expected = filter_devices(devices, wanted)
-    assert_success(
-        client.retrieve(query_uri,
-            query='foo=bar owner=jathan hostname=foo-bar1'),
-        expected
-    )
-
-
 def test_update(client, user_client, user, site):
     """Test updating a device using pk."""
     # URIs

--- a/tests/api_tests/test_networks.py
+++ b/tests/api_tests/test_networks.py
@@ -321,42 +321,6 @@ def test_set_queries(client, site):
     )
 
 
-def test_set_queries_with_concrete_fields(client, site):
-    """Test filtering resources via set_queries using attrs
-    and concrete_fields"""
-
-    # URIs
-    attr_uri = site.list_uri('attribute')
-    net_uri = site.list_uri('network')
-    query_uri = site.query_uri('network')
-
-    # Pre-load the attributes
-    client.post(attr_uri, data=load('attributes.json'))
-
-    # Populate the network objects and retreive them for testing.
-    client.post(net_uri, data=load('networks.json'))
-    net_resp = client.retrieve(net_uri)
-    networks = get_result(net_resp)
-
-    # INTERSECTION: foo=bar owner=jathan prefix_length=16 ip_version=4
-    wanted = ['169.254.0.0/16']
-    expected = filter_networks(networks, wanted)
-    assert_success(
-        client.retrieve(query_uri,
-            query='foo=bar owner=jathan prefix_length=16 ip_version=4'),
-        expected
-    )
-
-    # INTERSECTION: foo=bar ip_version=4
-    wanted = ['10.0.0.0/8', '169.254.0.0/16']
-    expected = filter_networks(networks, wanted)
-    assert_success(
-        client.retrieve(query_uri,
-            query='foo=bar ip_version=4'),
-        expected
-    )
-
-
 def test_update(live_server, user, site):
     """Test updating Networks by pk and natural_key."""
     admin_client = Client(live_server, 'admin')

--- a/tests/model_tests/test_attributes.py
+++ b/tests/model_tests/test_attributes.py
@@ -49,36 +49,6 @@ def test_conflict(site):
     )
 
 
-def test_attr_creation_name_in_concrete_fields(site):
-    with pytest.raises(exc.ValidationError):
-        models.Attribute.objects.create(
-            resource_name='Device',
-            site=site, name='hostname'
-        )
-
-
-def test_set_query_with_concrete_fields(site):
-    models.Attribute.objects.create(
-        site=site, resource_name='Network', name='test'
-    )
-    models.Network.objects.create(
-        site=site, cidr=u'10.0.0.0/24', attributes={'test': 'bar'}
-    )
-
-    assert list(models.Network.objects.set_query(
-        'test=bar prefix_length=24'))[0].cidr == '10.0.0.0/24'
-
-    models.Attribute.objects.create(
-        site=site, resource_name='Device', name='foo'
-    )
-    models.Device.objects.create(
-        site=site, hostname='foobar', attributes={'foo': 'bar'}
-    )
-
-    assert list(models.Device.objects.set_query(
-        'foo=bar hostname=foobar'))[0].hostname == 'foobar'
-
-
 def test_validation(site, transactional_db):
     with pytest.raises(exc.ValidationError):
         models.Attribute.objects.create(


### PR DESCRIPTION
Reverts dropbox/nsot#334
We are reverting this change due to unexpected issues faced with the `Interface` resource having `type` as a concrete field. These issues were found when running unit tests on internal Dropbox services. We will address these issues and cut a new release once these issues have been accounted for and resolved.