### PR TITLE
Bug Fix For Issue #344

### DIFF
--- a/nsot/api/views.py
+++ b/nsot/api/views.py
@@ -636,6 +636,8 @@ class NetworkViewSet(ResourceViewSet):
         network = self.get_resource_object(pk, site_pk)
         assignments = network.assignments.all()
 
+        return self.list(request, queryset=assignments, *args, **kwargs)
+
     @list_route(methods=['get'])
     def reserved(self, request, site_pk=None, *args, **kwargs):
         """Display all reserved Networks."""

--- a/nsot/api/views.py
+++ b/nsot/api/views.py
@@ -653,7 +653,7 @@ class NetworkViewSet(ResourceViewSet):
         :param instance:
             Model instance to delete
         """
-        log.debug('NsotViewSet.perform_destroy() obj = %r', instance)
+        log.debug('NetworkViewSet.perform_destroy() obj = %r', instance)
         change = models.Change.objects.create(
             obj=instance, user=self.request.user, event='Delete'
         )

--- a/nsot/models/network.py
+++ b/nsot/models/network.py
@@ -11,7 +11,6 @@ import netaddr
 
 from .. import exc, fields, util, validators
 from . import constants
-from .assignment import Assignment
 from .resource import Resource, ResourceManager
 
 

--- a/nsot/models/network.py
+++ b/nsot/models/network.py
@@ -619,6 +619,10 @@ class Network(Resource):
 
 # Signals
 def refresh_assignment_interface_networks(sender, instance, **kwargs):
+    """This signal fires each time a Network object is saved. Upon save,
+    the signal iterates through all the child networks of the network
+    being saved and cleans the addresses and networks assigned to the
+    interfaces (if any) to which these child networks have been assigned."""
     for child in instance.children.all():
         for assignment in child.assignments.all():
             assignment.interface.clean_addresses()

--- a/nsot/models/network.py
+++ b/nsot/models/network.py
@@ -622,7 +622,12 @@ def refresh_assignment_interface_networks(sender, instance, **kwargs):
     """This signal fires each time a Network object is saved. Upon save,
     the signal iterates through all the child networks of the network
     being saved and cleans the addresses and networks assigned to the
-    interfaces (if any) to which these child networks have been assigned."""
+    interfaces (if any) to which these child networks have been assigned.
+
+    We need to clean the addresses on an Interface upon a call to save()
+    on Network due to the Interface model caching _addresses & _networks
+    which causes the update on the Network object to not cascade onto the
+    corresponding Interface object."""
     for child in instance.children.all():
         for assignment in child.assignments.all():
             assignment.interface.clean_addresses()

--- a/nsot/models/network.py
+++ b/nsot/models/network.py
@@ -11,6 +11,7 @@ import netaddr
 
 from .. import exc, fields, util, validators
 from . import constants
+from .assignment import Assignment
 from .resource import Resource, ResourceManager
 
 
@@ -588,3 +589,17 @@ class Network(Resource):
             'state': self.state,
             'attributes': self.get_attributes(),
         }
+
+
+# Signals
+def refresh_assignment_interface_networks(sender, instance, **kwargs):
+    for child in instance.children.all():
+        for assignment in child.assignments.all():
+            assignment.interface.clean_addresses()
+            assignment.interface.save()
+
+
+models.signals.post_save.connect(
+    refresh_assignment_interface_networks, sender=Network,
+    dispatch_uid='refresh_interface_assignment_networks_post_save_network'
+)

--- a/tests/api_tests/test_networks.py
+++ b/tests/api_tests/test_networks.py
@@ -420,8 +420,10 @@ def test_deletion(site, client):
     net2 = get_result(net2_resp)
     net2_obj_uri = site.detail_uri('network', id=net2['id'])
 
+    print net1_obj_uri
     # Don't allow delete when there's an attached subnet/ip
-    assert_error(client.delete(net1_obj_uri), status.HTTP_409_CONFLICT)
+    assert_error(client.delete(net1_obj_uri), 
+        status.HTTP_409_CONFLICT)
 
     # Delete the child Network
     client.delete(net2_obj_uri)
@@ -470,7 +472,8 @@ def test_force_deletion(site, client):
         - force delete /23 should raise an error.
     """
     # Delete /24 will fail, because it has a child.
-    assert_error(client.destroy(net3_obj_uri), status.HTTP_409_CONFLICT)
+    assert_error(client.destroy(net3_obj_uri),
+        status.HTTP_409_CONFLICT)
 
     # Forcefully delete the /24
     assert_deleted(client.destroy(net3_obj_uri, force_delete=True))

--- a/tests/api_tests/test_networks.py
+++ b/tests/api_tests/test_networks.py
@@ -420,7 +420,6 @@ def test_deletion(site, client):
     net2 = get_result(net2_resp)
     net2_obj_uri = site.detail_uri('network', id=net2['id'])
 
-    print net1_obj_uri
     # Don't allow delete when there's an attached subnet/ip
     assert_error(client.delete(net1_obj_uri), 
         status.HTTP_409_CONFLICT)

--- a/tests/model_tests/test_interfaces.py
+++ b/tests/model_tests/test_interfaces.py
@@ -286,6 +286,29 @@ def test_device_hostname(device):
                                          name='eth0')
 
 
+def test_interface_networks_refresh(device):
+    """Test the interface parent networks refresh upon reparenting of a
+    Network object"""
+    cidr = '10.1.1.1/32'
+    parent_network = models.Network.objects.create(
+        cidr='10.1.1.0/24', site=device.site
+    )
+    intf_address = models.Network.objects.create(
+        cidr=cidr, site=device.site
+    )
+    intf = models.Interface.objects.create(device=device, name='eth0')
+    intf.assign_address(cidr)
+    intf.clean_addresses()
+    assert intf.get_networks() == ['10.1.1.0/24']
+
+    new_parent_network = models.Network.objects.create(
+        cidr='10.1.1.0/27', site=device.site
+    )
+
+    intf_obj = models.Interface.objects.get(device=device, name='eth0')
+    intf_obj.clean_addresses()
+    assert intf_obj.get_networks() == ['10.1.1.0/27']
+
 # TODO(jathan): This isn't implemented yet, but the idea is that there will be
 # pluggable parenting/inheritance strategies, with the "SNMP index" strategy as
 # the default/built-in (e.g. snmp_index, snmp_parent_index).

--- a/tests/model_tests/test_interfaces.py
+++ b/tests/model_tests/test_interfaces.py
@@ -299,14 +299,15 @@ def test_interface_networks_refresh(device):
     intf = models.Interface.objects.create(device=device, name='eth0')
     intf.assign_address(cidr)
     intf.clean_addresses()
+    intf.save()
     assert intf.get_networks() == ['10.1.1.0/24']
 
     new_parent_network = models.Network.objects.create(
         cidr='10.1.1.0/27', site=device.site
     )
+    new_parent_network.save()
 
     intf_obj = models.Interface.objects.get(device=device, name='eth0')
-    intf_obj.clean_addresses()
     assert intf_obj.get_networks() == ['10.1.1.0/27']
 
 # TODO(jathan): This isn't implemented yet, but the idea is that there will be


### PR DESCRIPTION
This bug fix adds a new signal to `models/network.py` that fires each time a Network object is saved.

The signal cycles through all the child networks of this network object (if any) and by means of the `Assignment` relationship, determines the interfaces they are assigned to and cleans the addresses on those interfaces to refresh the interfaces to reflect the change to the network object.