### PR TITLE
Add clarification on Docker NSoT config's SECRET_KEY

### DIFF
--- a/docker/conf/nsot.conf.py
+++ b/docker/conf/nsot.conf.py
@@ -58,6 +58,10 @@ SERVE_STATIC_FILES = True
 # A URL-safe base64-encoded 32-byte key. This must be kept secret. Anyone with
 # this key is able to create and read messages. This key is used for
 # encryption/decryption of sessions and auth tokens.
+#
+# WARNING: This default value provided here is for development purposes only!
+# If deploying to a production environment, be sure to specify a NSOT_SECRET
+# environment variable. See docker/README.md for more details.
 SECRET_KEY = os.environ.get(
     'NSOT_SECRET', 'nJvyRB8tckUWvquJZ3ax4QnhpmqTgVX2k3CDY13yK9E='
 )


### PR DESCRIPTION
This `SECRET_KEY` is meant to be overwritten in a prod environment, but a
default is provided for easing development. This adds a comment to
clarify that this should be overridden via environment variable in a
production environment.