### PR TITLE
Update PyYAML to 5.1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,6 +13,7 @@ py~=1.5.2
 pytest~=3.4.1
 pytest-django~=3.1.2
 pytest-pythonpath~=0.6.0
+PyYAML~=5.1
 Sphinx~=1.3.6
 sphinx-autobuild~=0.6.0
 sphinx-rtd-theme~=0.1.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,6 @@ logan~=0.7.2
 MarkupSafe~=0.23.0
 netaddr~=0.7.18
 openapi-codec~=1.3.2
-PyYAML~=3.11.0
 requests~=2.20.0
 simplejson~=3.13.2
 static3~=0.6.1


### PR DESCRIPTION
PyYaml < 5.1 is vulnerable to https://nvd.nist.gov/vuln/detail/CVE-2017-18342. This PR forces PyYaml to a patched version without the vulnerability. I've also moved the PyYaml dep to requirements-dev since we do not use the library in the main code, but only to satisfy the dependencies of sphinx-autobuild in requirements-dev.txt.

I verified that I can pip install, setup, run nsot and pass all unit tests with this change.