### PR TITLE
Fix spacing in network error message

### DIFF
--- a/nsot/models/network.py
+++ b/nsot/models/network.py
@@ -569,9 +569,9 @@ class Network(Resource):
                     for child in children:
                         if child.is_leaf_node():
                             raise exc.Conflict(
-                                'You cannot forcefully delete a network that'
+                                'You cannot forcefully delete a network that '
                                 'does not have a parent, and whose children '
-                                ' are leaf nodes.'
+                                'are leaf nodes.'
                             )
                 # Otherwise, update all children to use the new parent and
                 # delete the old parent of these child nodes.


### PR DESCRIPTION
This is causing a test in pynsot to fail:

```
>           assert "cannot forcefully delete a network that does not have a parent" in result.output
E           AssertionError: assert 'cannot forcefully delete a network that does not have a parent' in '[FAILURE] You cannot forcefully delete a network thatdoes not have a parent, and whose children  are leaf nodes.\n'
E            +  where '[FAILURE] You cannot forcefully delete a network thatdoes not have a parent, and whose children  are leaf nodes.\n' = <Result SystemExit(u'\x1b[31m[FAILURE] \x1b[0mYou cannot forcefully delete a network thatdoes not have a parent, and whose children  are leaf nodes.',)>.output

tests/test_app.py:881: AssertionError
```

See https://github.com/dropbox/pynsot/pull/169 for the pynsot issue.