### PR TITLE
chore: Use --no-cache-dir flag to pip in Dockerfiles, to save space

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,14 +32,14 @@ RUN apt-get --quiet=2 install -y \
 
 RUN apt-get --quiet=2 install -y python-psycopg2
 RUN apt-get --quiet=2 install -y sqlite3
-RUN pip install MySQL-Python
-RUN pip install psycopg2
+RUN pip install --no-cache-dir MySQL-Python
+RUN pip install --no-cache-dir psycopg2
 # upgrade pip to fix https://github.com/dropbox/nsot/issues/277
-RUN pip install -U setuptools
+RUN pip install --no-cache-dir -U setuptools
 
 # Try to run this as late as possible for layer caching - this version will be
 # updated every update so let the build not take longer than necessary
-RUN pip install nsot==1.4.6
+RUN pip install --no-cache-dir nsot==1.4.6
 
 COPY conf /etc/nsot
 

--- a/docker/Dockerfile.sub
+++ b/docker/Dockerfile.sub
@@ -32,14 +32,14 @@ RUN apt-get --quiet=2 install -y \
 
 RUN apt-get --quiet=2 install -y python-psycopg2
 RUN apt-get --quiet=2 install -y sqlite3
-RUN pip install MySQL-Python
-RUN pip install psycopg2
+RUN pip install --no-cache-dir MySQL-Python
+RUN pip install --no-cache-dir psycopg2
 # upgrade pip to fix https://github.com/dropbox/nsot/issues/277
-RUN pip install -U setuptools
+RUN pip install --no-cache-dir -U setuptools
 
 # Try to run this as late as possible for layer caching - this version will be
 # updated every update so let the build not take longer than necessary
-RUN pip install nsot=={{ NSOT_VERSION }}
+RUN pip install --no-cache-dir nsot=={{ NSOT_VERSION }}
 COPY conf /etc/nsot
 
 ENTRYPOINT ["nsot-server", "--config=/etc/nsot/nsot.conf.py"]


### PR DESCRIPTION
Using "--no-cache-dir" flag in pip install ,make sure dowloaded packages
by pip don't cached on system . This is a best practise which make sure
to fetch ftom repo instead of using local cached one . Further , in case
of Docker Containers , by restricing caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>